### PR TITLE
Refactor: Begin Server-Side Auth and Layout Cleanup

### DIFF
--- a/apps/web/src/components/AdminLayout.tsx
+++ b/apps/web/src/components/AdminLayout.tsx
@@ -1,20 +1,40 @@
 import { Menu } from 'lucide-react';
 import Link from 'next/link';
 
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import AdminSidebar from '@/components/pages/admin/navigation/AdminSidebar';
 import AdminSidebarMobile from '@/components/pages/admin/navigation/AdminSidebarMobile';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { DownOutlined } from '@ant-design/icons';
 import { Button, Dropdown, MenuProps } from 'antd';
-import { AppProps } from 'next/app';
-import { useContext } from 'react';
-import Logo from '../../components/ui/logo';
-import { auth } from '../../config';
-
-export default function AdminDashboard({ Component, pageProps }: AppProps) {
-  const { user } = useContext(TropTixContext);
+import { useContext, useEffect } from 'react';
+import Logo from './ui/logo';
+import { auth } from '../config';
+import { usePathname, useRouter } from 'next/navigation';
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { user, loading } = useContext(TropTixContext);
+  const pathname = usePathname();
+  const router = useRouter();
   const logoSize = 40;
+
+  // TODO: This is temporary to simplify the logic in the WebNavigator. Route protection should be checked server side.
+  useEffect(() => {
+    if (
+      (pathname.includes('admin') || pathname.includes('account')) &&
+      !loading &&
+      !user?.id
+    ) {
+      router.push('/auth/signup');
+    }
+
+    if (pathname.includes('admin') && !loading && user && !user.isOrganizer) {
+      router.push('/');
+    }
+  }, [loading, pathname, router, user]);
 
   let items: MenuProps['items'];
 
@@ -83,7 +103,7 @@ export default function AdminDashboard({ Component, pageProps }: AppProps) {
           </div>
         </header>
         <main className="flex flex-1 flex-col gap-4 lg:gap-6 lg:p-6">
-          <Component {...pageProps} />
+          {children}
         </main>
       </div>
     </div>

--- a/apps/web/src/components/AuthProvider.tsx
+++ b/apps/web/src/components/AuthProvider.tsx
@@ -3,9 +3,7 @@
 import { TROPTIX_ORGANIZER_ALLOW_LIST } from '@/firebase/remoteConfig';
 import { User, initializeUser } from '@/hooks/types/User';
 import { cn } from '@/lib/utils';
-import AdminDashboard from '@/pages/admin/AdminDashboard';
 import { LoadingOutlined } from '@ant-design/icons';
-import { Analytics } from '@vercel/analytics/react';
 import { Spin } from 'antd';
 import { onAuthStateChanged } from 'firebase/auth';
 import {
@@ -13,12 +11,10 @@ import {
   getRemoteConfig,
   getValue,
 } from 'firebase/remote-config';
-import type { AppProps } from 'next/app';
 import { Inter } from 'next/font/google';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { createContext, useContext, useEffect, useState } from 'react';
 import { app, auth } from '../config';
-import Header from './ui/header';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -33,33 +29,19 @@ const emptyUser: User = {
 
 export const TropTixContext = createContext({
   user: emptyUser,
+  loading: true,
 });
 
 export const useTropTixContext = () => useContext(TropTixContext);
 
-export default function WebNavigator({
-  Component,
-  pageProps,
-  router,
-}: AppProps) {
+export default function AuthProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   const pathname = usePathname();
   const [user, setUser] = useState<User>();
   const [loading, setLoading] = useState(true);
-  // const router = useRouter();
-
-  useEffect(() => {
-    if (
-      (pathname.includes('admin') || pathname.includes('account')) &&
-      !loading &&
-      !user?.id
-    ) {
-      router.push('/auth/signup');
-    }
-
-    if (pathname.includes('admin') && !loading && user && !user.isOrganizer) {
-      router.push('/');
-    }
-  }, [loading, pathname, router, user]);
 
   useEffect(() => {
     async function isUserAnOrganizer(userId: string) {
@@ -115,6 +97,7 @@ export default function WebNavigator({
     <TropTixContext.Provider
       value={{
         user: user as User,
+        loading,
       }}
     >
       {loading && (pathname === '/' || pathname === '/home') ? (
@@ -135,25 +118,7 @@ export default function WebNavigator({
             className={`${inter.variable} font-inter antialiased text-gray-900 tracking-tight`}
           >
             <div className="flex flex-col overflow-hidden supports-[overflow:clip]:overflow-clip">
-              <Analytics />
-              {!pathname.includes('admin') ? (
-                <div>
-                  <Header />
-                  <div className="flex-grow border-x">
-                    <Component {...pageProps} />
-                  </div>
-                </div>
-              ) : (
-                <div>
-                  {user && (
-                    <AdminDashboard
-                      Component={Component}
-                      pageProps={pageProps}
-                      router={router}
-                    />
-                  )}
-                </div>
-              )}
+              {children}
             </div>
           </div>
         </div>

--- a/apps/web/src/components/pages/admin/manage-account/social-media.tsx
+++ b/apps/web/src/components/pages/admin/manage-account/social-media.tsx
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { Button, Drawer, List, Popconfirm, message } from 'antd';
 import { useContext, useState } from 'react';
 import { PutUsersType, putUsers } from 'troptix-api';

--- a/apps/web/src/components/pages/admin/manage-event/order-guest-list.tsx
+++ b/apps/web/src/components/pages/admin/manage-event/order-guest-list.tsx
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { Ticket, TicketStatus } from '@/hooks/types/Ticket';
 import {
   PostTicketRequest,

--- a/apps/web/src/components/pages/admin/manage-event/promotions-codes.tsx
+++ b/apps/web/src/components/pages/admin/manage-event/promotions-codes.tsx
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { Spinner } from '@/components/ui/spinner';
 import { Promotion, createPromotion } from '@/hooks/types/Promotion';
 import {

--- a/apps/web/src/components/pages/admin/manage-event/ticket-comp-form.tsx
+++ b/apps/web/src/components/pages/admin/manage-event/ticket-comp-form.tsx
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { CustomInput } from '@/components/ui/input';
 import {
   ComplementaryOrder,

--- a/apps/web/src/components/pages/admin/manage-event/user-delegation.tsx
+++ b/apps/web/src/components/pages/admin/manage-event/user-delegation.tsx
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { Spinner } from '@/components/ui/spinner';
 import {
   DelegatedAccess,

--- a/apps/web/src/components/pages/event/CheckoutContainer.tsx
+++ b/apps/web/src/components/pages/event/CheckoutContainer.tsx
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { Spinner } from '@/components/ui/spinner';
 import { Checkout, initializeCheckout } from '@/hooks/types/Checkout';
 import { TicketType } from '@/hooks/types/Ticket';

--- a/apps/web/src/components/pages/event/tickets-checkout-forms.tsx
+++ b/apps/web/src/components/pages/event/tickets-checkout-forms.tsx
@@ -2,7 +2,7 @@ import { List, Typography, message } from 'antd';
 import { format } from 'date-fns';
 import { useContext, useState } from 'react';
 
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { Button, ButtonWithIcon } from '@/components/ui/button';
 import { InputWithLabel } from '@/components/ui/input';
 import { TypographyH3 } from '@/components/ui/typography';

--- a/apps/web/src/components/ui/admin-header.tsx
+++ b/apps/web/src/components/ui/admin-header.tsx
@@ -20,7 +20,7 @@ import {
 import { usePathname } from 'next/navigation';
 import { AiOutlineHome } from 'react-icons/ai';
 import { auth } from '../../config';
-import { TropTixContext } from '../WebNavigator';
+import { TropTixContext } from '../AuthProvider';
 import AdminMobileMenu from './admin-mobile-menu';
 
 export default function AdminHeader() {

--- a/apps/web/src/components/ui/admin-mobile-menu.tsx
+++ b/apps/web/src/components/ui/admin-mobile-menu.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useContext, useEffect, useRef, useState } from 'react';
 import { auth } from '../../config';
-import { TropTixContext } from '../WebNavigator';
+import { TropTixContext } from '../AuthProvider';
 
 export default function AdminMobileMenu() {
   const { user } = useContext(TropTixContext);

--- a/apps/web/src/components/ui/header.tsx
+++ b/apps/web/src/components/ui/header.tsx
@@ -9,7 +9,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import React from 'react';
 import { auth } from '../../config';
-import { TropTixContext } from '../WebNavigator';
+import { TropTixContext } from '../AuthProvider';
 import MobileMenu from './mobile-menu';
 
 export default function Header() {

--- a/apps/web/src/components/ui/mobile-menu.tsx
+++ b/apps/web/src/components/ui/mobile-menu.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useContext, useEffect, useRef, useState } from 'react';
 import { auth } from '../../config';
-import { TropTixContext } from '../WebNavigator';
+import { TropTixContext } from '../AuthProvider';
 
 export default function MobileMenu() {
   const [mobileNavOpen, setMobileNavOpen] = useState<boolean>(false);

--- a/apps/web/src/hooks/useEvents.ts
+++ b/apps/web/src/hooks/useEvents.ts
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { FetchEventOptions } from '@/pages/api/events/[[...slug]]';
 import { Prisma } from '@prisma/client';
 import {

--- a/apps/web/src/hooks/useFetchEvents.tsx
+++ b/apps/web/src/hooks/useFetchEvents.tsx
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { useQuery } from '@tanstack/react-query';
 import { useContext } from 'react';
 

--- a/apps/web/src/hooks/useOrders.ts
+++ b/apps/web/src/hooks/useOrders.ts
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { message } from 'antd';
 import { useContext } from 'react';

--- a/apps/web/src/hooks/useTicket.ts
+++ b/apps/web/src/hooks/useTicket.ts
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useContext } from 'react';
 import { Ticket } from './types/Ticket';

--- a/apps/web/src/hooks/useTicketType.tsx
+++ b/apps/web/src/hooks/useTicketType.tsx
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { updateTicketQuantities } from '@/lib/checkoutHelper';
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import { useContext } from 'react';

--- a/apps/web/src/hooks/useUser.tsx
+++ b/apps/web/src/hooks/useUser.tsx
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useContext } from 'react';
 import { SocialMediaAccount, User } from './types/User';

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -29,8 +29,7 @@ function App({ Component, pageProps, router }: AppProps) {
   const shouldInjectToolbar = process.env.NODE_ENV === 'development';
   const pathname = usePathname();
 
-  const Layout = pathname.includes('admin') ? AdminLayout : GlobalLayout;
-
+  const Layout = pathname.startsWith('/admin') ? AdminLayout : GlobalLayout;
   return (
     <ConfigProvider
       theme={{

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { VercelToolbar } from '@vercel/toolbar/next';
-import WebNavigator from '@/components/WebNavigator';
+import AuthProvider from '@/components/AuthProvider';
 import { MetaHead } from '@/components/utils/MetaHead';
 import '@/styles/globals.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -10,10 +10,26 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { ErrorFallback } from '@/components/utils/ErrorFallback';
 import { ConfigProvider } from 'antd';
 import { withRouter } from 'next/router';
+import AdminLayout from '../components/AdminLayout';
+import Header from '@/components/ui/header';
+import { usePathname } from 'next/navigation';
+import { Analytics } from '@vercel/analytics/react';
+
+function GlobalLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <Header />
+      <div className="flex-grow border-x">{children}</div>
+    </div>
+  );
+}
 
 function App({ Component, pageProps, router }: AppProps) {
   const queryClient = new QueryClient();
   const shouldInjectToolbar = process.env.NODE_ENV === 'development';
+  const pathname = usePathname();
+
+  const Layout = pathname.includes('admin') ? AdminLayout : GlobalLayout;
 
   return (
     <ConfigProvider
@@ -42,11 +58,12 @@ function App({ Component, pageProps, router }: AppProps) {
           </MetaHead>
 
           <QueryClientProvider client={queryClient}>
-            <WebNavigator
-              pageProps={pageProps}
-              Component={Component}
-              router={router}
-            />
+            <AuthProvider>
+              <Layout>
+                <Analytics />
+                <Component {...pageProps} />
+              </Layout>
+            </AuthProvider>
             {shouldInjectToolbar && <VercelToolbar />}
           </QueryClientProvider>
         </>

--- a/apps/web/src/pages/admin/add-event/index.tsx
+++ b/apps/web/src/pages/admin/add-event/index.tsx
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import AddEventFormPage from '@/components/pages/admin/add-event/add-event-form';
 import { useContext, useState } from 'react';
 import { Event } from 'troptix-models';

--- a/apps/web/src/pages/auth/reset-password/index.tsx
+++ b/apps/web/src/pages/auth/reset-password/index.tsx
@@ -5,7 +5,7 @@ export const metadata = {
   description: 'Page description',
 };
 
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { resetPassword } from '@/firebase/auth';
 import { Button, Form, message } from 'antd';
 import { useRouter } from 'next/router';

--- a/apps/web/src/pages/auth/signin/index.tsx
+++ b/apps/web/src/pages/auth/signin/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { signInWithEmail, signInWithGoogle } from '@/firebase/auth';
 import { isInputBad, isValidEmail } from '@/lib/utils';
 import { Button, Form, message } from 'antd';

--- a/apps/web/src/pages/auth/signup/index.tsx
+++ b/apps/web/src/pages/auth/signup/index.tsx
@@ -5,7 +5,7 @@ export const metadata = {
   description: 'Page description',
 };
 
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { CustomInput } from '@/components/ui/input';
 import { signInWithGoogle, signUpWithEmail } from '@/firebase/auth';
 import { isInputBad, isValidEmail } from '@/lib/utils';

--- a/apps/web/src/pages/event/[id].tsx
+++ b/apps/web/src/pages/event/[id].tsx
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import TicketDrawer from '@/components/pages/event/ticket-drawer';
 import TicketModal from '@/components/pages/event/ticket-modal';
 import { ButtonWithIcon } from '@/components/ui/button';

--- a/apps/web/src/pages/order-confirmation/index.tsx
+++ b/apps/web/src/pages/order-confirmation/index.tsx
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { Spinner } from '@/components/ui/spinner';
 import { useFetchOrderById } from '@/hooks/useOrders';
 import { getDateFormatter, getFormattedCurrency } from '@/lib/utils';

--- a/apps/web/src/pages/order-details/index.tsx
+++ b/apps/web/src/pages/order-details/index.tsx
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import EditTicketForm from '@/components/pages/order-details/edit-ticket-form';
 import { Spinner } from '@/components/ui/spinner';
 import { OrderStatus } from '@/hooks/types/Order';

--- a/apps/web/src/pages/tickets/index.tsx
+++ b/apps/web/src/pages/tickets/index.tsx
@@ -1,4 +1,4 @@
-import { TropTixContext } from '@/components/WebNavigator';
+import { TropTixContext } from '@/components/AuthProvider';
 import { Spinner } from '@/components/ui/spinner';
 import { GetOrdersType, useFetchOrderById } from '@/hooks/useOrders';
 import { getDateFormatter } from '@/lib/utils';


### PR DESCRIPTION
This is the first step in refactoring how we handle User Sessions, Authorization, and Authentication across the app.

#### Goals
- Currently, authentication and authorization are handled only on the **client side**, which can be easily bypassed.
- The long-term goal is to introduce **server-side auth checks** by setting cookies after Firebase authentication and validating those cookies on the server.

#### WebNavigator Refactor
- The `WebNavigator` component was doing too much:
  - Checking auth state and user roles
  - Managing layouts
  - Enforcing admin authorization
- It has been renamed to **AuthProvider**, and now focuses **only** on checking auth state and user roles.

#### Layout Changes
- **AdminDashboard** was essentially wrapping all admin routes, so it was refactored into a proper **layout pattern** to make this explicit.
- Introduced a new `GlobalLayout` that currently just wraps the `Header` component.
- Updated `_app.tsx` to support these layout changes.


---

This pull request includes significant changes to the layout and navigation components in the web application. The primary objective is to refactor the layout structure by introducing a new `AdminLayout` component and updating the `WebNavigator` and `_app` components to use this new layout.

### Layout and Navigation Refactor:

* [`apps/web/src/components/AdminLayout.tsx`](diffhunk://#diff-0e074f40b92761053dd7139239a9d54a016a306ac0de38688468ba6f3acc7e8eL10-R18): Renamed from `apps/web/src/pages/admin/AdminDashboard.tsx` and refactored to use `children` instead of `Component` and `pageProps`. [[1]](diffhunk://#diff-0e074f40b92761053dd7139239a9d54a016a306ac0de38688468ba6f3acc7e8eL10-R18) [[2]](diffhunk://#diff-0e074f40b92761053dd7139239a9d54a016a306ac0de38688468ba6f3acc7e8eL86-R89)
* [`apps/web/src/components/WebNavigator.tsx`](diffhunk://#diff-fe52c4a124f435d48b185f97961eabcd15eb9a43b926bc56f672491a113a76deL6-L21): Updated to use `children` instead of `Component`, `pageProps`, and `router`. Removed `AdminDashboard` import and replaced it with `AdminLayout` in `_app.tsx`. [[1]](diffhunk://#diff-fe52c4a124f435d48b185f97961eabcd15eb9a43b926bc56f672491a113a76deL6-L21) [[2]](diffhunk://#diff-fe52c4a124f435d48b185f97961eabcd15eb9a43b926bc56f672491a113a76deL41-R44) [[3]](diffhunk://#diff-fe52c4a124f435d48b185f97961eabcd15eb9a43b926bc56f672491a113a76deL138-R134)
* [`apps/web/src/pages/_app.tsx`](diffhunk://#diff-a3569d521976a5ee9e97e2b2e005bf7423bc96bb49397b3adfb09cde5862bf93R13-R32): Introduced `GlobalLayout` and `AdminLayout` components. Updated the main `App` component to conditionally use `AdminLayout` for admin routes and `GlobalLayout` for other routes. [[1]](diffhunk://#diff-a3569d521976a5ee9e97e2b2e005bf7423bc96bb49397b3adfb09cde5862bf93R13-R32) [[2]](diffhunk://#diff-a3569d521976a5ee9e97e2b2e005bf7423bc96bb49397b3adfb09cde5862bf93L45-R66)