### PR TITLE
Fix error in middleware

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -15,7 +15,7 @@ export function middleware(req: NextRequest) {
   try {
     // Verify that the token is present and logged in but NOT if valid
     const decoded = jwt.decode(token || '') as any;
-    if (!decoded?.uid) throw new Error('Missing UID');
+    if (!decoded?.user_id) throw new Error('Missing user_id');
     return NextResponse.next();
   } catch (error) {
     const url = new URL('/auth/signin', req.url);


### PR DESCRIPTION
This pull request includes a change to the `middleware` function in the `apps/web/src/middleware.ts` file. The change updates the verification process to check for the presence of `user_id` instead of `uid`.

* [`apps/web/src/middleware.ts`](diffhunk://#diff-38835f18d088a33913f19851f92c095dfc487f1574e21c14c8e400f4ade65e45L18-R18): Modified the `middleware` function to check for `user_id` in the decoded token instead of `uid`.