### PR TITLE
PR 3 Refactor: Simplify ticket selection state and remove client calculations

### DIFF
--- a/apps/web/src/components/pages/event/ticket-drawer.tsx
+++ b/apps/web/src/components/pages/event/ticket-drawer.tsx
@@ -31,6 +31,7 @@ export default function TicketDrawer({
         handleCompleteStripePayment,
         renderCheckoutStep,
         formMethods,
+        ticketTypes,
       }) => (
         <>
           <Drawer
@@ -61,9 +62,6 @@ export default function TicketDrawer({
               </div>
               <footer className="border-t border-gray-200 px-6 pb-6">
                 <div className="flex mt-4">
-                  <div className="text-xl mr-2">
-                    {getFormattedCurrency(checkout.total)}
-                  </div>
                   <div>
                     <Button
                       onClick={() => setSummaryDrawerOpen(true)}
@@ -134,6 +132,13 @@ export default function TicketDrawer({
                           if (summary?.subtotal) {
                             subtotal = summary.subtotal;
                           }
+                          let price = 0;
+                          if (ticketTypes) {
+                            const ticketType = ticketTypes.find(
+                              (ticket) => ticket.id === id
+                            );
+                            price = ticketType?.price ?? 0;
+                          }
 
                           if (summary?.quantitySelected) {
                             quantitySelected = summary.quantitySelected;
@@ -151,7 +156,7 @@ export default function TicketDrawer({
                                   <div className="ml-4">
                                     <div className="text-base text-end">
                                       {getFormattedCurrency(
-                                        subtotal * quantitySelected
+                                        price * quantitySelected
                                       )}
                                     </div>
                                   </div>
@@ -170,23 +175,6 @@ export default function TicketDrawer({
                         }}
                       />
 
-                      <div className="w-full flex my-4">
-                        <div className="grow">
-                          <div className="text-base">Subtotal:</div>
-                          <div className="text-base">Taxes & Fees:</div>
-                        </div>
-                        <div className="ml-4">
-                          <div className="ml-4">
-                            <div className="text-base text-end">
-                              {getFormattedCurrency(checkout.subtotal)}
-                            </div>
-                            <div className="text-base text-end">
-                              {getFormattedCurrency(checkout.fees)}
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-
                       <div
                         style={{
                           flex: 1,
@@ -194,19 +182,6 @@ export default function TicketDrawer({
                           backgroundColor: '#D3D3D3',
                         }}
                       />
-
-                      <div className="w-full flex my-4">
-                        <div className="grow">
-                          <div className="text-2xl font-bold">Total:</div>
-                        </div>
-                        <div className="ml-4">
-                          <div className="ml-4">
-                            <div className="text-2xl font-bold">
-                              {getFormattedCurrency(checkout.total)} USD
-                            </div>
-                          </div>
-                        </div>
-                      </div>
                     </div>
                   )}
                 </div>

--- a/apps/web/src/components/pages/event/ticket-modal.tsx
+++ b/apps/web/src/components/pages/event/ticket-modal.tsx
@@ -31,6 +31,7 @@ export default function TicketModal({
         handleCompleteStripePayment,
         renderCheckoutStep,
         formMethods,
+        ticketTypes,
       }) => (
         <Dialog
           open={isTicketModalOpen}
@@ -124,7 +125,15 @@ export default function TicketModal({
                             dataSource={Array.from(checkout.tickets?.keys())}
                             split={false}
                             renderItem={(id: any, index: number) => {
+                              let price = 0;
                               const summary = checkout.tickets.get(id);
+                              if (ticketTypes) {
+                                const ticketType = ticketTypes.find(
+                                  (ticket) => ticket.id === id
+                                );
+                                price = ticketType?.price ?? 0;
+                              }
+                              console.log('summary', summary);
                               let subtotal = 0;
                               let quantitySelected = 0;
                               if (summary?.subtotal) {
@@ -147,7 +156,7 @@ export default function TicketModal({
                                       <div className="ml-4">
                                         <div className="text-sm text-end">
                                           {getFormattedCurrency(
-                                            subtotal * quantitySelected
+                                            price * quantitySelected
                                           )}
                                         </div>
                                       </div>
@@ -166,23 +175,6 @@ export default function TicketModal({
                             }}
                           />
 
-                          <div className="w-full flex my-4">
-                            <div className="grow">
-                              <div className="text-sm">Subtotal:</div>
-                              <div className="text-sm">Taxes & Fees:</div>
-                            </div>
-                            <div className="ml-4">
-                              <div className="ml-4">
-                                <div className="text-sm text-end">
-                                  {getFormattedCurrency(checkout.subtotal)}
-                                </div>
-                                <div className="text-sm text-end">
-                                  {getFormattedCurrency(checkout.fees)}
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-
                           <div
                             style={{
                               flex: 1,
@@ -190,19 +182,6 @@ export default function TicketModal({
                               backgroundColor: '#D3D3D3',
                             }}
                           />
-
-                          <div className="w-full flex my-4">
-                            <div className="grow">
-                              <div className="text-xl font-bold">Total:</div>
-                            </div>
-                            <div className="ml-4">
-                              <div className="ml-4">
-                                <div className="text-xl font-bold text-end">
-                                  {getFormattedCurrency(checkout.total)} USD
-                                </div>
-                              </div>
-                            </div>
-                          </div>
                         </div>
                       )}
                     </div>

--- a/apps/web/src/components/pages/event/ticket-modal.tsx
+++ b/apps/web/src/components/pages/event/ticket-modal.tsx
@@ -133,7 +133,7 @@ export default function TicketModal({
                                 );
                                 price = ticketType?.price ?? 0;
                               }
-                              console.log('summary', summary);
+                              // Removed unnecessary console.log statement.
                               let subtotal = 0;
                               let quantitySelected = 0;
                               if (summary?.subtotal) {

--- a/apps/web/src/components/pages/event/tickets-checkout-forms.tsx
+++ b/apps/web/src/components/pages/event/tickets-checkout-forms.tsx
@@ -148,7 +148,7 @@ export default function TicketsCheckoutForm({
     const updatedTickets: Map<string, CheckoutTicket> = new Map(
       checkout.tickets
     );
-    console.log('updatedTickets', updatedTickets);
+    // Removed console.log to prevent unintended logging in production.
     const currentQuantity =
       updatedTickets.get(ticket.id)?.quantitySelected || 0;
     const newQuantity = reduce ? currentQuantity - 1 : currentQuantity + 1;

--- a/apps/web/src/pages/event/[id].tsx
+++ b/apps/web/src/pages/event/[id].tsx
@@ -145,12 +145,7 @@ export default function EventDetailPage(props) {
           WebkitBackgroundSize: 'cover',
         }}
       >
-        <TicketModal
-          event={event}
-          isTicketModalOpen={isTicketModalOpen}
-          handleCancel={handleCancel}
-        />
-        {/* {isMobile ? (
+        {isMobile ? (
           <TicketDrawer
             event={event}
             isTicketModalOpen={isTicketModalOpen}
@@ -162,7 +157,7 @@ export default function EventDetailPage(props) {
             isTicketModalOpen={isTicketModalOpen}
             handleCancel={handleCancel}
           />
-        )} */}
+        )}
         <div className="w-full md:min-h-screen flex backdrop-blur-3xl">
           <div className={`max-w-5xl mx-auto p-4 sm:p-8`}>
             <div className="md:flex mt-32">


### PR DESCRIPTION
**Note** These PRs are stacked as part of a large checkout refactor.
PR 1: #179 (Merged)
PR 2: #180 (Merged)
PR 3: #181 (In Review)
PR 4: #182  (In Review)
PR 5: #183 (In Review)

**Overview**

Building on PR 1 and 2, which I have already merged. This PR focuses on simplifying the state management related to ticket selection within the checkout form (`TicketsCheckoutForm.tsx`). It removes client-side calculations of subtotals, fees, and totals that were previously triggered during quantity changes or promotion applications. It also simplifies the UI display to only show base prices/fees during selection.

**Key Changes:**

* Refactored the `updateCost` function (or equivalent +/- button handlers) in `TicketsCheckoutForm.tsx`:
    * Removed all logic calculating per-ticket or overall `subtotal`, `fees`, `total`.
    * The function now *only* updates the selected quantity for the specific `ticketTypeId` in the `checkout.tickets` state object/Map via `setCheckout`.
* Simplified the price/fee display within the ticket list (`renderItem`):
    * Removed conditional logic related to `promotionApplied` state.
    * Now displays only the static base `price` and base `fees` which will be obtained from the `checkoutConfig` prop in a future PR
* Started the temporary removal of the Promotion validation and application logic. This will be re-implemeneted in a later PR. 
* Simplified the Order Summary display in `Ticket Modal`/`Ticket Drawer`:
    * Removed the display of overall "Subtotal", "Taxes & Fees", and "Total" previously derived directly from the main `checkout` state object.
    * The summary now primarily shows the list of selected tickets and quantities, along with the client-calculated *estimate* totals (`cartSubtotal`, `cartFees` provided by `CheckoutContainer`).

**Reasoning/Motivation:**

* Aligns with the "dumb form" goal by removing complex client-side financial calculations.
* Prepares for authoritative server-side calculation by ensuring the client state only tracks user intent (selected quantities) before validation.
* Reduces complexity and potential for calculation discrepancies within the client-side components.
* It simplifies display logic, making it easier to understand and maintain.

**How Changes Affect Flow:**

* Clicking +/- buttons only changes the quantity state, not the calculated totals displayed elsewhere *during selection*.
* The main Order Summary no longer shows running totals based on potentially inaccurate client calculations (only the client estimate remains). Authoritative totals will come from the server validation response later.

**Testing Considerations:**

* Verify clicking +/- correctly updates the displayed quantity for a ticket type and the `checkout.tickets` state.
* Verify the displayed price and fees *per ticket* in the list remain static regardless of quantity selected or promotions applied.
* Verify the Order Summary sections for overall Subtotal/Fees/Total (previously based on `checkout` state) are removed or replaced by the client estimate (`cartSubtotal`/`cartFees`).

**Next Steps:**

* PR 4 will introduce the new server-side endpoint (`/api/checkout/initiate`) which will perform the authoritative validation and calculations previously removed from the client.
