### PR TITLE
PR 4: Implement Server-Side Checkout Validation & Initiation Endpoint

### DIFF
--- a/apps/web/src/components/pages/event/ticket-modal.tsx
+++ b/apps/web/src/components/pages/event/ticket-modal.tsx
@@ -133,7 +133,6 @@ export default function TicketModal({
                                 );
                                 price = ticketType?.price ?? 0;
                               }
-                              // Removed unnecessary console.log statement.
                               let subtotal = 0;
                               let quantitySelected = 0;
                               if (summary?.subtotal) {

--- a/apps/web/src/components/pages/event/tickets-checkout-forms.tsx
+++ b/apps/web/src/components/pages/event/tickets-checkout-forms.tsx
@@ -20,11 +20,6 @@ import {
   CheckoutTicket,
   initializeCheckoutTicket,
 } from '@/hooks/types/Checkout';
-import {
-  Checkout,
-  CheckoutTicket,
-  initializeCheckoutTicket,
-} from '@/hooks/types/Checkout';
 import { TicketsType, TicketType } from '@/hooks/types/Ticket';
 import {
   GetPromotionsRequest,

--- a/apps/web/src/components/pages/event/tickets-checkout-forms.tsx
+++ b/apps/web/src/components/pages/event/tickets-checkout-forms.tsx
@@ -20,6 +20,11 @@ import {
   CheckoutTicket,
   initializeCheckoutTicket,
 } from '@/hooks/types/Checkout';
+import {
+  Checkout,
+  CheckoutTicket,
+  initializeCheckoutTicket,
+} from '@/hooks/types/Checkout';
 import { TicketsType, TicketType } from '@/hooks/types/Ticket';
 import {
   GetPromotionsRequest,

--- a/apps/web/src/hooks/useCheckout.tsx
+++ b/apps/web/src/hooks/useCheckout.tsx
@@ -1,0 +1,54 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { UserDetailsFormData } from '@/lib/schemas/checkoutSchema';
+import { ValidationResponse } from '@/types/IntiateCheckout';
+
+export interface InitiateCheckoutVariables {
+  eventId: string;
+  selectedTickets: Record<string, number>;
+  userDetails: UserDetailsFormData;
+  promotionCode?: string;
+}
+
+const initiateCheckoutApiCall = async (
+  variables: InitiateCheckoutVariables
+): Promise<ValidationResponse> => {
+  const requestBody = {
+    eventId: variables.eventId,
+    selectedTickets: variables.selectedTickets,
+    userDetails: variables.userDetails,
+    promotionCode: variables.promotionCode,
+  };
+
+  const response = await fetch('/api/checkout/initiate', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  const responseData = await response.json();
+
+  if (!response.ok) {
+    throw new Error(
+      responseData.message || `Checkout initiation failed (${response.status})`
+    );
+  }
+
+  return responseData as ValidationResponse;
+};
+
+/**
+ * React Query hook using useMutation to call the checkout initiation endpoint.
+ * Handles server-side validation, pending order creation, and Stripe Payment Intent creation.
+ *
+ * @returns {UseMutationResult<ValidationResponse, Error, InitiateCheckoutVariables>}
+ * Includes mutate, data, error, isPending, etc.
+ */
+export function useInitiateCheckout() {
+  return useMutation<ValidationResponse, Error, InitiateCheckoutVariables>({
+    mutationFn: initiateCheckoutApiCall,
+  });
+}

--- a/apps/web/src/pages/api/checkout/initiate.ts
+++ b/apps/web/src/pages/api/checkout/initiate.ts
@@ -1,0 +1,558 @@
+// pages/api/checkout/initiate.ts
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '@/server/prisma'; // Adjust path
+import Stripe from 'stripe';
+// Import your calculation helpers, e.g., calculateFeesServerSide
+// Import shared types (ensure these are defined, e.g., in hooks/types/):
+import { UserDetailsFormData } from '@/lib/schemas/checkoutSchema'; // Adjust path
+import { getCookie } from 'cookies-next';
+import { OrderStatus, TicketFeeStructure, TicketTypes } from '@prisma/client'; // Assuming you have OrderStatus enum in Prisma schema
+import { PrismaClient } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+import admin from '@/server/lib/firebaseAdmin';
+import { generateId } from '@/lib/utils';
+import {
+  ValidatedItem,
+  ValidatedItemMessage,
+  ValidationResponse,
+  ValidationResponseMessage,
+} from '@/types/IntiateCheckout';
+// Define the expected Request Body structure
+
+// Initialize Stripe (use environment variables for secret key)
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  // @ts-ignore
+  apiVersion: '2024-04-10', // Use the latest API version
+});
+
+interface InitiateRequestData {
+  eventId: string;
+  selectedTickets: Record<string, number>; // { ticketTypeId: quantity }
+  userDetails: UserDetailsFormData;
+  promotionCode?: string;
+}
+
+interface TicketTypeWithStats extends TicketTypes {
+  pendingOrders: number;
+  completedOrders: number;
+  _count: {
+    tickets: number;
+  };
+  tickets: {
+    id: string;
+  }[];
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ValidationResponse | { message: string }>
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+  let userId: string | null = null;
+
+  const token = await getCookie('fb-token', { req: req, res: res });
+  if (!token) {
+    userId = null;
+  } else {
+    const decoded = await admin.auth().verifyIdToken(token as string);
+    userId = decoded.uid;
+  }
+
+  // TODO: Add authentication and Anonymous User Check so that we can only authenticated users hitting this endpoint
+
+  try {
+    const {
+      eventId,
+      selectedTickets,
+      userDetails,
+      promotionCode,
+    }: InitiateRequestData = req.body;
+
+    console.log('req.body', req.body);
+
+    if (
+      !eventId ||
+      !selectedTickets ||
+      Object.keys(selectedTickets).length === 0
+    ) {
+      return res
+        .status(400)
+        .json({ message: 'Missing required fields or no tickets selected' });
+    }
+
+    // --- Use Prisma Transaction ---
+    const validationResult = await prisma.$transaction(
+      async (tx: PrismaClient) => {
+        const event = await tx.events.findUnique({
+          where: { id: eventId },
+          include: {
+            ticketTypes: {
+              select: {
+                id: true,
+                name: true,
+                price: true,
+                quantity: true,
+                quantitySold: true,
+                maxPurchasePerUser: true,
+                saleStartDate: true,
+                saleEndDate: true,
+                ticketingFees: true,
+                ticketType: true,
+                discountCode: true,
+              },
+            },
+          },
+        });
+
+        if (!event) throw new Error('Event not found');
+
+        const pendingAndCompletedOrders = await tx.ticketTypes.findMany({
+          where: {
+            eventId: eventId,
+          },
+          include: {
+            // count of tickets sold
+            _count: {
+              select: {
+                tickets: {
+                  where: {
+                    order: {
+                      status: OrderStatus.COMPLETED,
+                    },
+                  },
+                },
+              },
+            },
+            // array of tickets pending
+            tickets: {
+              where: {
+                order: {
+                  status: OrderStatus.PENDING,
+                },
+              },
+              select: {
+                id: true,
+              },
+            },
+          },
+        });
+        // This needs a better name
+        const ticketStats = pendingAndCompletedOrders.map((ticketType) => ({
+          ...ticketType,
+          pendingOrders: ticketType.tickets.length,
+          completedOrders: ticketType._count.tickets,
+        }));
+
+        // --- Initialize Response Object ---
+        const response: ValidationResponse = {
+          isValid: false,
+          wasAdjusted: false,
+          validatedItems: [],
+          subtotal: 0,
+          fees: 0,
+          total: 0,
+          promotionApplied: null,
+          message: null,
+          isFree: false,
+          orderId: null, // Will be added after order creation
+          clientSecret: null, // Will be added after PI creation
+          expiresAt: null, // Will be added after order creation
+        };
+
+        for (const ticketTypeId in selectedTickets) {
+          const requestedQuantity = selectedTickets[ticketTypeId];
+          if (requestedQuantity <= 0) continue;
+          const ticketType =
+            ticketStats.find((tt) => tt.id === ticketTypeId) ?? null;
+
+          const { validatedQuantity, message } = validateTicketType(
+            ticketType,
+            requestedQuantity
+          );
+          if (validatedQuantity < requestedQuantity) {
+            response.wasAdjusted = true;
+          }
+          response.validatedItems.push({
+            ticketTypeId,
+            name: ticketType?.name ?? 'Unknown Ticket Type',
+            requestedQuantity,
+            validatedQuantity,
+            pricePerTicket: ticketType?.price ?? 0,
+            feesPerTicket:
+              ticketType?.ticketingFees ===
+              TicketFeeStructure.ABSORB_TICKET_FEES
+                ? 0
+                : calculateFees(ticketType?.price ?? 0),
+            message,
+          });
+        }
+        // If any tickets have a validated quantity greater than 0, set isValid to true otherwise set to false
+        response.isValid = response.validatedItems.some(
+          (item) => item.validatedQuantity > 0
+        );
+        // --- Set the response message ---
+        // This probably needs to be refactored
+        if (response.wasAdjusted && response.isValid) {
+          response.message = ValidationResponseMessage.SomeTicketsUnavailable;
+        }
+        if (!response.wasAdjusted && !response.isValid) {
+          response.message = ValidationResponseMessage.AllTicketInvalid;
+        }
+        if (Object.keys(selectedTickets).length === 0) {
+          response.message = ValidationResponseMessage.NoTicketsSelected;
+        }
+        if (!response.wasAdjusted && response.isValid) {
+          response.message = ValidationResponseMessage.AllTicketsValidated;
+        }
+
+        if (response.isValid) {
+          // TODO: Add promotion code validation and calculation
+          const { subtotal, fee } = calculateCartTotal(
+            ticketStats,
+            response.validatedItems
+          );
+          response.subtotal = parseFloat(subtotal.toFixed(2));
+          response.fees = parseFloat(fee.toFixed(2));
+          response.total = parseFloat((subtotal + fee).toFixed(2));
+          response.isFree = response.subtotal === 0;
+          console.log('isFree', response.isFree);
+        }
+        // --- Create the Order ---
+        if (response.isValid) {
+          const order = await createOrderInDatabase(
+            tx,
+            {
+              eventId,
+              userId: userId ?? undefined, // Guest checkout if no user id
+              userDetails,
+              validatedItems: response.validatedItems,
+              subtotal: response.subtotal,
+              fees: response.fees,
+              total: response.total,
+            },
+            response.isFree ? DbOrderType.Free : DbOrderType.Paid
+          );
+          response.orderId = order.id;
+
+          // --- Create the Payment Intent ---
+          // If paid, create PI and update order with PI ID
+          // Fetch Customer ID from Stripe
+          // TODO: Create a Customer Table to store customer details
+          let customerId = '';
+          if (userId) {
+            const user = await prisma.users.findUnique({
+              where: {
+                id: userId,
+              },
+            });
+            if (!user?.stripeId) {
+              const customer = await stripe.customers.create({
+                name: userDetails.firstName + ' ' + userDetails.lastName,
+                email: userDetails.email,
+              });
+              await prisma.users.update({
+                where: { id: userId },
+                data: { stripeId: customer.id },
+              });
+              customerId = customer.id;
+            } else {
+              customerId = user?.stripeId;
+            }
+          } else {
+            const customer = await stripe.customers.create({
+              name: userDetails.firstName + ' ' + userDetails.lastName,
+              email: userDetails.email,
+            });
+            customerId = customer.id;
+          }
+          if (!response.isFree) {
+            const paymentIntent = await stripe.paymentIntents.create({
+              amount: response.total * 100,
+              currency: 'usd',
+              customer: customerId,
+              description: `Order # ${order.id} for ${event.name}`,
+              automatic_payment_methods: {
+                enabled: true,
+              },
+              metadata: {
+                orderId: order.id,
+                eventId: eventId,
+                eventName: event.name,
+                userId: userId ?? 'Guest',
+              },
+            });
+            response.clientSecret = paymentIntent.client_secret;
+            await tx.orders.update({
+              where: { id: order.id },
+              data: {
+                stripePaymentId: paymentIntent.id,
+                stripeCustomerId: customerId,
+              },
+            });
+          }
+        }
+        return response;
+      },
+      {
+        timeout: 15000, // 15 seconds timeout
+      }
+    );
+    console.log('response', validationResult);
+    return res.status(200).json(validationResult);
+  } catch (error) {
+    console.error('Error in checkout initiation:', error);
+    return res.status(500).json({ message: 'Internal Server Error' });
+  }
+}
+/**
+ * Validate the ticket type
+ * @param ticketType - The ticket type to validate
+ * @param requestedQuantity - The quantity requested
+ * @returns - The validation result
+ *
+ * isValid: boolean - Whether the ticket type is valid
+ * message: string - The message to display to the user
+ * validatedQuantity: number - The quantity validated
+ */
+function validateTicketType(
+  ticketType: TicketTypeWithStats | null,
+  requestedQuantity: number
+): { message: ValidatedItemMessage; validatedQuantity: number } {
+  if (!ticketType) {
+    return {
+      message: ValidatedItemMessage.TicketTypeNotFound,
+      validatedQuantity: 0,
+    };
+  }
+  // Check if the saleStartDate is in the future
+  if (
+    ticketType.saleStartDate &&
+    new Date(ticketType.saleStartDate) > new Date()
+  ) {
+    return {
+      message: ValidatedItemMessage.SaleNotStarted,
+      validatedQuantity: 0,
+    };
+  }
+
+  // Check if the ticketType is on sale
+  if (ticketType.saleEndDate && new Date(ticketType.saleEndDate) < new Date()) {
+    return {
+      message: ValidatedItemMessage.SaleEnded,
+      validatedQuantity: 0,
+    };
+  }
+
+  // Check if the quantity remaing is greater than 0
+  if (
+    ticketType.quantity -
+      (ticketType?.quantitySold ?? 0) -
+      (ticketType?.pendingOrders ?? 0) <=
+    0
+  ) {
+    return {
+      message: ValidatedItemMessage.SoldOut,
+      validatedQuantity: 0,
+    };
+  }
+  // Tickets are available, check if the quantity requested is greater than the quantity available
+  if (
+    (ticketType?.quantitySold ?? 0) +
+      (ticketType?.pendingOrders ?? 0) +
+      requestedQuantity >
+    ticketType.quantity
+  ) {
+    const availableQuantity =
+      ticketType.quantity -
+      (ticketType?.quantitySold ?? 0) -
+      (ticketType?.pendingOrders ?? 0);
+    const maxPurchasePerUser = ticketType.maxPurchasePerUser ?? 0;
+    const validatedQuantity = Math.min(availableQuantity, maxPurchasePerUser);
+
+    return {
+      message: ValidatedItemMessage.QuantityReducedMaxAvailable,
+      validatedQuantity: validatedQuantity,
+    };
+  }
+
+  return {
+    message: ValidatedItemMessage.Available,
+    validatedQuantity: requestedQuantity,
+  };
+}
+
+function calculateCartTotal(
+  ticketStats: TicketTypeWithStats[],
+  validatedTickets: ValidatedItem[]
+): { subtotal: number; fee: number; total: number } {
+  let subtotal = 0;
+  let fee = 0;
+  // Calculate the subtotal for the cart
+  for (const ticket of validatedTickets) {
+    if (ticket.validatedQuantity <= 0) continue;
+    const ticketType = ticketStats.find((tt) => tt.id === ticket.ticketTypeId);
+    if (ticketType) {
+      subtotal += ticketType.price * ticket.validatedQuantity;
+      fee +=
+        ticketType.ticketingFees === TicketFeeStructure.ABSORB_TICKET_FEES
+          ? 0
+          : calculateFees(ticketType.price * ticket.validatedQuantity);
+    }
+  }
+  // Calculate the total for the cart
+  const total = subtotal + fee;
+  return {
+    subtotal: parseFloat(subtotal.toFixed(2)),
+    fee: parseFloat(fee.toFixed(2)),
+    total: parseFloat(total.toFixed(2)),
+  };
+}
+/**
+ * Calculate the fees for a given subtotal
+ * @param subtotal - A subtotal amount (e.g. 100 or 100 * 2)
+ * @returns - The fees for the subtotal
+ */
+function calculateFees(subtotal: number): number {
+  if (subtotal === 0) return 0;
+  return parseFloat((subtotal * 0.03 + 0.3).toFixed(2));
+}
+
+export enum DbOrderType {
+  Paid = 'PAID',
+  Free = 'FREE',
+  Complementary = 'COMPLEMENTARY',
+}
+
+// Define the data needed to create any order
+interface CreateOrderData {
+  eventId: string;
+  userId?: string;
+  userDetails: UserDetailsFormData;
+  validatedItems: ValidatedItem[];
+  subtotal: number;
+  fees: number;
+  total: number;
+  stripePaymentIntentId?: string;
+  expiresAt?: Date;
+}
+
+/**
+ * Creates an order record in the database.
+ * Handles generating Prisma payload based on order type.
+ * Optionally updates ticket stats for completed non-paid orders.
+ * MUST be called within a Prisma transaction if transaction consistency is needed.
+ * @param prismaTx - The Prisma client or transaction client instance
+ * @param orderData - The validated and calculated order details
+ * @param orderType - The type of order being created
+ */
+export async function createOrderInDatabase(
+  prismaTx: Omit<
+    PrismaClient,
+    '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'
+  >, // Prisma transaction client type
+  orderData: CreateOrderData,
+  orderType: DbOrderType
+) {
+  let prismaOrderPayload: Prisma.OrdersCreateInput;
+
+  switch (orderType) {
+    case DbOrderType.Free:
+      prismaOrderPayload = getPrismaCreateOrderPayload(
+        orderData,
+        OrderStatus.COMPLETED,
+        true
+      );
+      break;
+
+    case DbOrderType.Paid:
+      prismaOrderPayload = getPrismaCreateOrderPayload(
+        orderData,
+        OrderStatus.PENDING,
+        false
+      );
+      break;
+
+    default:
+      throw new Error(`Unsupported order type for creation: ${orderType}`);
+  }
+
+  // --- Create the Order ---
+  const createdOrder = await prismaTx.orders.create({
+    data: prismaOrderPayload,
+  });
+
+  return createdOrder;
+}
+
+/**
+ * Creates a Prisma payload for creating an order in the database.
+ * Handles generating Prisma payload based on order type.
+ * @param orderData - The validated and calculated order details
+ * @param status - The status of the order
+ * @param isFree - Whether the order is free
+ * @returns - The Prisma payload for creating an order
+ */
+export function getPrismaCreateOrderPayload(
+  orderData: CreateOrderData,
+  status: OrderStatus,
+  isFree: boolean
+): Prisma.OrdersCreateInput {
+  // Map validated items (tickets) to the structure needed for OrderItems relation create
+  const orderItemsCreateData = orderData.validatedItems
+    .filter((item) => item.validatedQuantity > 0)
+    .flatMap((item) =>
+      Array.from({ length: item.validatedQuantity }, () => ({
+        id: generateId(), // Generate a unique id for the order item
+        ticketTypeId: item.ticketTypeId,
+        subtotal: isFree ? 0 : item.pricePerTicket,
+        fees: isFree ? 0 : item.feesPerTicket,
+        total: isFree ? 0 : item.pricePerTicket + item.feesPerTicket,
+        firstName: orderData.userDetails.firstName,
+        lastName: orderData.userDetails.lastName,
+        email: orderData.userDetails.email,
+        eventId: orderData.eventId,
+      }))
+    );
+
+  // Base order input
+  const orderInput: Prisma.OrdersCreateInput = {
+    id: generateId(), // Generate a unique id for the order
+    status: status,
+    subtotal: isFree ? 0 : orderData.subtotal,
+    fees: isFree ? 0 : orderData.fees,
+    total: isFree ? 0 : orderData.total,
+    stripePaymentId:
+      status === OrderStatus.PENDING ? orderData.stripePaymentIntentId : null,
+
+    // Customer Details
+    firstName: orderData.userDetails.firstName,
+    lastName: orderData.userDetails.lastName,
+    email: orderData.userDetails.email,
+    // Add other customer details from orderData.userDetails if needed/available
+
+    // Relations
+    event: {
+      connect: {
+        id: orderData.eventId,
+      },
+    },
+    tickets: {
+      createMany: {
+        data: orderItemsCreateData,
+      },
+    },
+  };
+
+  // Connect user if userId is provided (Guest checkout)
+  if (orderData.userId) {
+    orderInput.user = {
+      connect: {
+        id: orderData.userId,
+      },
+    };
+  }
+
+  return orderInput;
+}

--- a/apps/web/src/types/IntiateCheckout.ts
+++ b/apps/web/src/types/IntiateCheckout.ts
@@ -1,0 +1,41 @@
+export enum ValidationResponseMessage {
+  SomeTicketsUnavailable = 'Some tickets were unavailable or sold out and cart was adjusted',
+  AllTicketsValidated = 'All tickets are valid',
+  AllTicketInvalid = 'All tickets are invalid',
+  NoTicketsSelected = 'No tickets selected',
+  MissingRequiredFields = 'Missing required fields or no tickets selected',
+}
+
+export interface ValidationResponse {
+  isValid: boolean;
+  wasAdjusted: boolean;
+  validatedItems: ValidatedItem[];
+  subtotal: number;
+  fees: number;
+  total: number;
+  promotionApplied: string | null;
+  message: ValidationResponseMessage | null;
+  isFree: boolean;
+  orderId: string | null;
+  clientSecret: string | null;
+  expiresAt: string | null;
+}
+
+export enum ValidatedItemMessage {
+  Available = 'Available',
+  QuantityReducedMaxAvailable = 'Quantity Reduced: Max Available',
+  SoldOut = 'Sold Out',
+  SaleNotStarted = 'Sale Not Started',
+  SaleEnded = 'Sale Ended',
+  TicketTypeNotFound = 'Ticket Type Not Found',
+}
+
+export interface ValidatedItem {
+  ticketTypeId: string;
+  name: string;
+  requestedQuantity: number;
+  validatedQuantity: number;
+  pricePerTicket: number;
+  feesPerTicket: number;
+  message: ValidatedItemMessage;
+}


### PR DESCRIPTION
**Note** These PRs are stacked as part of a large checkout refactor.
PR 1: #179 (Merged)
PR 2: #180 (Merged)
PR 3: #181 (In Review)
PR 4: #182  (In Review)
PR 5: #183 (In Review)

**Overview/Context:**

This PR introduces the core server-side logic for the refactored checkout, building on PR #181 . It creates the new `POST /api/checkout/initiate` endpoint responsible for validating availability, calculating authoritative totals/fees (handling adjustments), creating a pending order, creating a Stripe Payment Intent, and returning a detailed response. It also refactors the corresponding client-side call (`useInitiateCheckout` hook and its API function).

**Key Changes:**

* Created new API route `pages/api/checkout/initiate.ts`.
* Implemented handler logic within `/initiate`:
    * Uses Prisma transaction (`$transaction`).
    * Fetches authoritative event/ticket/availability data from DB.
    * Performs validation (sale dates, stock levels vs. pending/completed, max per user) using `validateTicketType` helper. Handles partial availability/adjustments.
    * Calculates final `subtotal`, `fees`, `total` based on *validated* quantities and DB prices using `calculateCartTotal` helper (Note: Promotion logic still TODO). Determines `isFree` flag.
    * Creates pending `Order` record (with `status: PENDING`, calculated financials, `expiresAt`) using `createOrderInDatabase` helper if validation passes.
    * Creates/updates Stripe Customer record.
    * Creates Stripe Payment Intent (using calculated total, customerId, metadata) if order is valid and not free. Updates Order with `stripePaymentId`.
    * Returns detailed `ValidationResponse` object containing `isValid`, `wasAdjusted` (boolean indicating if quantities changed), `validatedItems` (with requested vs validated quantities, per-item messages, prices, fees), calculated financials, `orderId`, `clientSecret` (if applicable).
* Refactored the client-side API call function (`initiateCheckoutApiCall` within `useCheckout.tsx`):
    * Removed old client-side validation logic.
    * Now makes a `POST` request to `/api/checkout/initiate`.
    * Sends `eventId`, `selectedTickets`, `userDetails`, `promotionCode`, and `jwtToken`.
    * Returns the `ValidationResponse` promise. Includes error handling.
* Updated `useInitiateCheckout` hook to use the refactored API call function. Added basic `onError` message handling.
* Updated `handleNext` in `CheckoutContainer.tsx` to:
    * Prepare the correct `variables` (including `jwtToken`) for the `useInitiateCheckout` mutation.
    * Call `initiateCheckoutMutation.mutate`. (Note: Full `onSuccess` logic refinement happens in PR 5).

**Reasoning/Motivation:**

* Moves critical validation and financial calculation logic to the server, significantly improving security and reliability 
* Ensures checkout proceeds based on authoritative data, preventing client-side manipulation.
* Implements the "Create Pending then Confirm Adjustment" backend pattern, securing inventory early while allowing for user confirmation of changes.
* Provides a detailed API response for the client to react to various validation outcomes.

**How Changes Affect Flow:**

* When "Continue" is clicked, the client now calls the `/initiate` endpoint instead of performing client-side checks.
* The server performs all validation and calculations.
* The server creates the pending order and Payment Intent *before* returning to the client.
* The client receives a detailed response indicating success, failure, or success-with-adjustments.

**Testing Considerations:**

* **Backend:** Use `curl` or API testing tools (Postman, Insomnia) to hit `/initiate` with various scenarios: valid request, insufficient quantity, invalid promo code (once added), expired sale dates, event not found. Verify the `ValidationResponse` is correct for each case (check `isValid`, `wasAdjusted`, `validatedItems` quantities/messages, totals, `orderId`, `clientSecret`). Check database for pending order creation and Stripe dashboard for PI creation.
* **Client:** Verify `handleNext` calls the mutation. Use browser Network tab to inspect the request/response to `/initiate`. Add `console.log` in `onSuccess` (even if basic for now) to see the received `ValidationResponse`.

**Next Steps:**

* PR 5 will refine the client-side `CheckoutContainer` state management and fully implement the handling of the `ValidationResponse` in `handleNext`'s `onSuccess` callback (including the confirmation modal flow).