### PR TITLE
PR 5: Refactor CheckoutContainer State & Handle Initiation Response

### DIFF
--- a/apps/web/src/components/pages/event/confirmation-modal.tsx
+++ b/apps/web/src/components/pages/event/confirmation-modal.tsx
@@ -1,0 +1,90 @@
+// Create a new file, e.g., components/checkout/AdjustmentConfirmationModal.tsx
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { ValidationResponse } from '@/types/checkout';
+import { getFormattedCurrency } from '@/lib/utils'; // Adjust path
+
+interface AdjustmentConfirmationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  response: ValidationResponse | null;
+}
+
+export function AdjustmentConfirmationModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  response,
+}: AdjustmentConfirmationModalProps) {
+  if (!response) return null; // Don't render if no data
+
+  const handleConfirm = () => {
+    onConfirm();
+  };
+
+  const handleCancel = () => {
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      {' '}
+      <DialogContent className="sm:max-w-lg">
+        {' '}
+        <DialogHeader>
+          <DialogTitle>Confirm Cart Changes</DialogTitle>
+          <DialogDescription>
+            Some items in your cart were adjusted due to availability. Please
+            review the updated details below.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="my-4 space-y-4 max-h-60 overflow-y-auto p-1">
+          <h4 className="font-semibold mb-2">Updated Items:</h4>
+          {response.validatedItems
+            .filter((item) => item.validatedQuantity > 0)
+            .map((item, index) => (
+              <div
+                key={index}
+                className="flex justify-between items-center text-sm py-2"
+              >
+                <span>
+                  {item.validatedQuantity} x {item.name}
+                </span>
+                <span>
+                  {getFormattedCurrency(
+                    item.pricePerTicket * item.validatedQuantity
+                  )}
+                </span>
+              </div>
+            ))}
+          <div
+            style={{ flex: 1, height: 1, backgroundColor: '#D3D3D3' }}
+            className="my-4"
+          />
+          <div className="pt-2 font-semibold flex justify-between text-base">
+            {' '}
+            <span>New Total:</span>
+            <span>{getFormattedCurrency(response.total)}</span>
+          </div>
+        </div>
+        <DialogFooter className="sm:justify-between pt-4">
+          {' '}
+          <Button type="button" variant="outline" onClick={handleCancel}>
+            Cancel Order
+          </Button>
+          <Button type="button" onClick={handleConfirm}>
+            Confirm & Proceed
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/hooks/useCheckout.tsx
+++ b/apps/web/src/hooks/useCheckout.tsx
@@ -1,7 +1,8 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { UserDetailsFormData } from '@/lib/schemas/checkoutSchema';
-import { ValidationResponse } from '@/types/IntiateCheckout';
+import { CheckoutConfigResponse, ValidationResponse } from '@/types/checkout';
+import { message } from 'antd';
 
 export interface InitiateCheckoutVariables {
   eventId: string;
@@ -50,5 +51,59 @@ const initiateCheckoutApiCall = async (
 export function useInitiateCheckout() {
   return useMutation<ValidationResponse, Error, InitiateCheckoutVariables>({
     mutationFn: initiateCheckoutApiCall,
+    onError: (error) => {
+      console.error('Initiate Checkout Error:', error);
+      message.error('Checkout failed. Please try again.');
+    },
+  });
+}
+
+const fetchCheckoutConfig = async (
+  eventId: string
+): Promise<CheckoutConfigResponse> => {
+  // TODO: Determine if auth is needed for this endpoint
+  // const { user } = useContext(TropTixContext); // Get user/token if needed
+  // const jwtToken = user?.jwtToken; // Example token retrieval
+
+  if (!eventId) {
+    throw new Error('Event ID is required to fetch checkout config.');
+  }
+
+  const url = `/api/checkout/config?eventId=${eventId}`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  const responseData = await response.json(); // Always try to parse JSON
+
+  if (!response.ok) {
+    throw new Error(
+      responseData.message ||
+        `Failed to fetch checkout config (${response.status})`
+    );
+  }
+
+  // Type assertion on success
+  return responseData as CheckoutConfigResponse;
+};
+
+/**
+ * React Query hook to fetch the initial configuration data needed for the
+ * checkout UI (available tickets, etc.) for a specific event.
+ * Calls GET /api/checkout/config?eventId=...
+ *
+ * @param {string | undefined} eventId - The ID of the event to fetch config for. Query disabled if falsy.
+ * @returns {UseQueryResult<CheckoutConfigResponseDTO, Error>}
+ */
+export function useFetchCheckoutConfig(eventId: string) {
+  return useQuery<CheckoutConfigResponse, Error>({
+    queryKey: ['checkout', 'config', eventId], // Query key array
+    queryFn: () => fetchCheckoutConfig(eventId),
+    enabled: !!eventId,
+    staleTime: 5 * 60 * 1000, // Data considered fresh for 5 minutes
   });
 }

--- a/apps/web/src/pages/api/checkout/config.ts
+++ b/apps/web/src/pages/api/checkout/config.ts
@@ -1,0 +1,131 @@
+// pages/api/checkout/config.ts
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '@/server/prisma'; // Adjust path to your Prisma client
+import { OrderStatus, TicketFeeStructure, TicketTypes } from '@prisma/client'; // Import necessary Prisma Enums
+import { calculateFees } from '@/server/lib/checkout';
+import { CheckoutConfigResponse, CheckoutTicket } from '@/types/checkout';
+
+interface TicketTypeWithStats extends TicketTypes {
+  pendingOrders: number;
+  completedOrders: number;
+  _count: {
+    tickets: number;
+  };
+  tickets: {
+    id: string;
+  }[];
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CheckoutConfigResponse | { message: string }>
+) {
+  // 1. Check HTTP Method
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    return res.status(405).json({
+      message: `Method ${req.method} Not Allowed`,
+    });
+  }
+
+  // TODO: Add authentication so only users or anonymous users can hit this endpoint
+  //let userId: string | null = null;
+
+  // Extract and Validate Query Parameters
+  const { eventId } = req.query;
+
+  if (!eventId || typeof eventId !== 'string') {
+    return res
+      .status(400)
+      .json({ message: 'Missing or invalid "eventId" query parameter.' });
+  }
+
+  try {
+    const ticketTypesData: TicketTypeWithStats[] =
+      await prisma.ticketTypes.findMany({
+        where: {
+          eventId: eventId,
+        },
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          price: true,
+          quantity: true, // Total capacity
+          maxPurchasePerUser: true,
+          saleStartDate: true,
+          saleEndDate: true,
+          ticketingFees: true,
+          ticketType: true,
+          discountCode: true,
+          _count: {
+            select: {
+              tickets: { where: { order: { status: OrderStatus.COMPLETED } } },
+            },
+          },
+          tickets: {
+            where: { order: { status: OrderStatus.PENDING } },
+            select: { id: true },
+          },
+        },
+      });
+
+    if (ticketTypesData.length === 0) {
+      const eventExists = await prisma.events.count({ where: { id: eventId } });
+      if (eventExists === 0) {
+        return res
+          .status(404)
+          .json({ message: `Event with ID ${eventId} not found.` });
+      }
+    }
+
+    const now = new Date();
+    const tickets: CheckoutTicket[] = ticketTypesData.map((tt) => {
+      const completedOrdersCount = tt._count.tickets;
+      const pendingOrdersCount = tt.tickets.length;
+      const stock = Math.max(
+        0,
+        tt.quantity - completedOrdersCount - pendingOrdersCount
+      );
+      const saleIsActive = now >= tt.saleStartDate && now <= tt.saleEndDate;
+
+      const maxAllowedToAdd = saleIsActive
+        ? Math.max(0, Math.min(stock, tt.maxPurchasePerUser))
+        : 0;
+      const ticketQuanityLow = stock < 10;
+      const fees =
+        tt.ticketingFees === TicketFeeStructure.PASS_TICKET_FEES
+          ? calculateFees(tt.price)
+          : 0;
+
+      return {
+        id: tt.id,
+        name: tt.name,
+        description: tt.description,
+        price: tt.price,
+        saleStartDate: tt.saleStartDate.toISOString(),
+        saleEndDate: tt.saleEndDate.toISOString(),
+        maxAllowedToAdd: maxAllowedToAdd,
+        fees: fees,
+        feeStructure: tt.ticketingFees,
+        ticketType: tt.ticketType,
+        ticketQuanityLow: ticketQuanityLow,
+      } as CheckoutTicket;
+    });
+
+    const responseData: CheckoutConfigResponse = {
+      tickets: tickets,
+    };
+
+    return res.status(200).json(responseData);
+  } catch (error) {
+    console.error(
+      `Error fetching checkout config for event ${eventId}:`,
+      error
+    );
+    return res.status(500).json({
+      message: 'Internal Server Error fetching checkout configuration.',
+    });
+  }
+}

--- a/apps/web/src/pages/event/[id].tsx
+++ b/apps/web/src/pages/event/[id].tsx
@@ -13,7 +13,7 @@ import { MetaHead } from '@/components/utils/MetaHead';
 import { useEvent } from '@/hooks/useEvents';
 import { useScreenSize } from '@/hooks/useScreenSize';
 
-import { Typography } from 'antd';
+import { Button, Typography } from 'antd';
 import {
   getDateRangeFormatter,
   getFormattedCurrency,
@@ -26,6 +26,14 @@ import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useContext, useState } from 'react';
 import prisma from '@/server/prisma';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 
 const { Paragraph } = Typography;
 
@@ -99,7 +107,7 @@ export default function EventDetailPage(props) {
   const { isMobile } = useScreenSize();
   const { isPending, data: event } = useEvent(eventId, props.event);
 
-  function handleCancel() {
+  function closeModal() {
     setIsTicketModalOpen(false);
   }
 
@@ -149,13 +157,13 @@ export default function EventDetailPage(props) {
           <TicketDrawer
             event={event}
             isTicketModalOpen={isTicketModalOpen}
-            handleCancel={handleCancel}
+            onClose={closeModal}
           />
         ) : (
           <TicketModal
             event={event}
             isTicketModalOpen={isTicketModalOpen}
-            handleCancel={handleCancel}
+            onClose={closeModal}
           />
         )}
         <div className="w-full md:min-h-screen flex backdrop-blur-3xl">

--- a/apps/web/src/server/lib/checkout.ts
+++ b/apps/web/src/server/lib/checkout.ts
@@ -1,0 +1,12 @@
+//TODO: Need to centralize the fee calculation and fee percentage
+/**
+ * Calculate the fees for a given price
+ * @param price - The price to calculate the fees for
+ * @returns The fees for the given price
+ */
+export function calculateFees(price: number) {
+  if (price === 0) return 0;
+  const fee = price * 0.04 + 0.3;
+  const tax = fee * 0.15;
+  return parseFloat((fee + tax).toFixed(2));
+}

--- a/apps/web/src/types/checkout.ts
+++ b/apps/web/src/types/checkout.ts
@@ -1,7 +1,12 @@
+import {
+  TicketType as PrismaTicketTypeEnum,
+  TicketFeeStructure,
+} from '@prisma/client';
+
 export enum ValidationResponseMessage {
   SomeTicketsUnavailable = 'Some tickets were unavailable or sold out and cart was adjusted',
-  AllTicketsValidated = 'All tickets are valid',
-  AllTicketInvalid = 'All tickets are invalid',
+  AllTicketsValidated = 'Tickets are available',
+  AllTicketInvalid = 'All tickets are unavailable',
   NoTicketsSelected = 'No tickets selected',
   MissingRequiredFields = 'Missing required fields or no tickets selected',
 }
@@ -38,4 +43,26 @@ export interface ValidatedItem {
   pricePerTicket: number;
   feesPerTicket: number;
   message: ValidatedItemMessage;
+}
+
+export interface CheckoutTicket {
+  id: string;
+  name: string;
+  description: string;
+  price: number;
+  saleStartDate: string; // ISO String
+  saleEndDate: string; // ISO String
+  maxAllowedToAdd: number;
+  fees: number;
+  feeStructure: TicketFeeStructure;
+  ticketType: PrismaTicketTypeEnum | null;
+  ticketQuanityLow: boolean;
+}
+
+export interface CheckoutConfigResponse {
+  tickets: CheckoutTicket[];
+  message?: string;
+  // Might want to include other relevant information like currency,
+  // currency
+  // Custom form fields set by the event owner
 }


### PR DESCRIPTION
**Note** These PRs are stacked as part of a large checkout refactor.
PR 1: #179 (Merged)
PR 2: #180 (Merged)
PR 3: #181 (In Review)
PR 4: #182  (In Review)
PR 5: #183 (In Review)

**Overview/Context:**

This PR completes the client-side refactoring initiated in PR 4, building on PR #182 . It simplifies the state managed by `CheckoutContainer.tsx`, removes obsolete client-side logic/state, and implements the full handling of the `ValidationResponse` received from the `/api/checkout/initiate` endpoint, including the "Create Pending then Confirm Adjustment" modal flow.

**Key Changes:**

* Simplified `CheckoutState` interface in `CheckoutContainer` to only include essential client state (`eventId`, `tickets: Record<string, number>`). Removed fields like `total`, `subtotal`, `fees`, user details.
* Updated `initializeCheckout` helper to reflect the simplified state.
* Removed the client-side `isFree` calculation; now relies on `validationResponse.isFree`.
* Refactored `handleNext`'s `onSuccess` callback for `initiateCheckoutMutation`:
    * Handles `!validationResponse.isValid` by showing an error and stopping/clearing cart.
    * Stores `orderId` and `clientSecret` from the response if valid.
    * Updates the local `checkout.tickets` state using `validationResponse.validatedItems` to reflect server adjustments.
    * Checks the `validationResponse.wasAdjusted` boolean flag.
    * If `wasAdjusted` is true, it stores `validationResponse` and opens the new `AdjustmentConfirmationModal`.
    * If `wasAdjusted` is false, it calls the new `proceedToNextStep` helper function directly.
* Added the `proceedToNextStep` helper function to handle routing (free orders) or advancing state (`setCurrent(1)`) for paid orders based on the `ValidationResponse`.
* Added `AdjustmentConfirmationModal` component rendering within `CheckoutContainer`, controlled by state (`isConfirmationOpen`, `confirmationData`). Modal actions (`onConfirm`/`onClose`) are wired up correctly.
* Added `useEffect` hook watching `isOpen` prop to reliably reset component state (`checkout.tickets`, `current` step, `orderId`, `clientSecret`, modal state) and RHF form (`formMethods.reset()`) when the modal/drawer is opened.
* Updated `TicketsCheckoutForm` type hints for `ticket` prop to use `CheckoutTicketConfig`.
* Updated client-side estimate calculation (`calculateCart`) and display (`TicketsCheckoutForm`, `TicketModal`/`Drawer`) to use pre-calculated `feesPerTicket` from the `checkoutConfig`.

**Reasoning/Motivation:**

* Completes the state simplification goal for `CheckoutContainer`
* Removes redundant client-side state and calculations now handled by the backend.
* Implements robust handling of the detailed server `ValidationResponse`, improving reliability.
* Implements the desired "Create Pending then Confirm Adjustment" user experience flow.
* Ensures a clean state each time the checkout process is opened.

**How Changes Affect Flow:**
* `CheckoutContainer` now manages significantly less derived state.
* The client fully trusts the server's validation result and calculated totals.
* If ticket quantities are adjusted by the server, the user is now presented with a confirmation modal before proceeding to payment.
* The checkout state is reliably reset each time the modal/drawer is opened.

**Testing Considerations:**

* Test opening/closing/reopening the modal - verify state resets correctly each time (empty cart, step 1, cleared form).
* Test the "happy path" (no adjustments needed) - verify it proceeds directly to payment (paid) or confirmation (free) after clicking "Continue".
* Test the "adjustment path":
    * Trigger a scenario where the server reduces quantity.
    * Verify the confirmation modal appears after clicking "Continue".
    * Verify the modal shows the correct adjustment message and updated total/items.
    * Test clicking "Cancel Order" - verify modal closes and checkout doesn't proceed.
    * Test clicking "Confirm & Proceed" - verify modal closes and checkout proceeds to the correct next step (payment/confirmation).
* Verify client-side estimated totals display correctly before validation.
