### PR TITLE
Update quantity sold for Free Orders

### DIFF
--- a/apps/web/src/pages/api/checkout/initiate.ts
+++ b/apps/web/src/pages/api/checkout/initiate.ts
@@ -6,7 +6,12 @@ import Stripe from 'stripe';
 // Import shared types (ensure these are defined, e.g., in hooks/types/):
 import { UserDetailsFormData } from '@/lib/schemas/checkoutSchema'; // Adjust path
 import { getCookie } from 'cookies-next';
-import { OrderStatus, TicketFeeStructure, TicketTypes } from '@prisma/client'; // Assuming you have OrderStatus enum in Prisma schema
+import {
+  OrderStatus,
+  TicketFeeStructure,
+  TicketStatus,
+  TicketTypes,
+} from '@prisma/client'; // Assuming you have OrderStatus enum in Prisma schema
 import { PrismaClient } from '@prisma/client';
 import { Prisma } from '@prisma/client';
 import admin from '@/server/lib/firebaseAdmin';
@@ -298,8 +303,18 @@ export default async function handler(
                 stripeCustomerId: customerId,
               },
             });
+          } else {
+            // Free orders need to update ticket quantity sold
+            // For each ticket in validatedItems, update the quantity sold
+            for (const ticket of response.validatedItems) {
+              await tx.ticketTypes.update({
+                where: { id: ticket.ticketTypeId },
+                data: { quantitySold: { increment: ticket.validatedQuantity } },
+              });
+            }
           }
         }
+
         return response;
       },
       {
@@ -511,6 +526,7 @@ export function getPrismaCreateOrderPayload(
         lastName: orderData.userDetails.lastName,
         email: orderData.userDetails.email,
         eventId: orderData.eventId,
+        status: isFree ? TicketStatus.AVAILABLE : TicketStatus.NOT_AVAILABLE,
       }))
     );
 

--- a/apps/web/src/pages/api/checkout/initiate.ts
+++ b/apps/web/src/pages/api/checkout/initiate.ts
@@ -1,17 +1,15 @@
 // pages/api/checkout/initiate.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
-import prisma from '@/server/prisma'; // Adjust path
+import prisma from '@/server/prisma';
 import Stripe from 'stripe';
-// Import your calculation helpers, e.g., calculateFeesServerSide
-// Import shared types (ensure these are defined, e.g., in hooks/types/):
-import { UserDetailsFormData } from '@/lib/schemas/checkoutSchema'; // Adjust path
+import { UserDetailsFormData } from '@/lib/schemas/checkoutSchema';
 import { getCookie } from 'cookies-next';
 import {
   OrderStatus,
   TicketFeeStructure,
   TicketStatus,
   TicketTypes,
-} from '@prisma/client'; // Assuming you have OrderStatus enum in Prisma schema
+} from '@prisma/client';
 import { PrismaClient } from '@prisma/client';
 import { Prisma } from '@prisma/client';
 import admin from '@/server/lib/firebaseAdmin';
@@ -23,7 +21,6 @@ import {
   ValidationResponseMessage,
 } from '@/types/checkout';
 import { calculateFees } from '@/server/lib/checkout';
-// Define the expected Request Body structure
 
 // Initialize Stripe (use environment variables for secret key)
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {


### PR DESCRIPTION
This pull request introduces updates to the `apps/web/src/pages/api/checkout/initiate.ts` file to enhance the handling of ticket orders, including support for free orders and improved ticket status management. The key changes are grouped into updates to ticket status and free order handling.

### Updates to ticket status:
* Added a new property to the `getPrismaCreateOrderPayload` function to set the ticket `status` based on whether the order is free or paid. Free tickets are marked as `TicketStatus.AVAILABLE`, while paid tickets are marked as `TicketStatus.NOT_AVAILABLE`.

### Free order handling:
* Implemented logic to update the `quantitySold` field for free orders by iterating over the validated items and incrementing the sold quantity for each ticket type. This ensures accurate tracking of ticket availability for free orders.

### Additional updates:
* Updated imports to include the `TicketStatus` enum from the Prisma client, which is used to manage ticket availability.