### PR TITLE
Move date utils to own file

### DIFF
--- a/apps/web/src/components/pages/event/tickets-checkout-forms.tsx
+++ b/apps/web/src/components/pages/event/tickets-checkout-forms.tsx
@@ -15,7 +15,7 @@ import { Button, ButtonWithIcon } from '@/components/ui/button';
 import { InputWithLabel } from '@/components/ui/input';
 import { TypographyH3 } from '@/components/ui/typography';
 import { CheckoutTicket } from '@/types/checkout';
-import { getDateFormatter } from '@/lib/utils';
+import { getDateFormatter } from '@/lib/dateUtils';
 import { MinusOutlined, PlusOutlined } from '@ant-design/icons';
 import { UseFormReturn } from 'react-hook-form';
 import { UserDetailsFormData } from '@/lib/schemas/checkoutSchema';

--- a/apps/web/src/lib/dateUtils.ts
+++ b/apps/web/src/lib/dateUtils.ts
@@ -1,0 +1,28 @@
+import { formatInTimeZone } from 'date-fns-tz';
+
+export function getDateFormatter(date: Date) {
+  return `${formatInTimeZone(date, 'America/New_York', 'MMM dd, yyyy, h:mm a')}`;
+}
+
+export function getDateRangeFormatter(start: Date, end: Date) {
+  const startDate = formatInTimeZone(
+    start,
+    'America/New_York',
+    'EEEE MMM dd, yyyy'
+  );
+  const endDate = formatInTimeZone(
+    end,
+    'America/New_York',
+    'EEEE MMM dd, yyyy'
+  );
+
+  if (startDate !== endDate) {
+    return `${startDate} - ${endDate}`;
+  }
+
+  return startDate;
+}
+
+export function getTimeRangeFormatter(start: Date, end: Date) {
+  return `${formatInTimeZone(start, 'America/New_York', 'h:mm a')} - ${formatInTimeZone(end, 'America/New_York', 'h:mm a')}`;
+}

--- a/apps/web/src/pages/event/[id].tsx
+++ b/apps/web/src/pages/event/[id].tsx
@@ -14,11 +14,8 @@ import { useEvent } from '@/hooks/useEvents';
 import { useScreenSize } from '@/hooks/useScreenSize';
 
 import { Button, Typography } from 'antd';
-import {
-  getDateRangeFormatter,
-  getFormattedCurrency,
-  getTimeRangeFormatter,
-} from '@/lib/utils';
+import { getDateRangeFormatter, getTimeRangeFormatter } from '@/lib/dateUtils';
+import { getFormattedCurrency } from '@/lib/utils';
 import { APIProvider, Map, Marker } from '@vis.gl/react-google-maps';
 
 import { Calendar, DollarSign, MapPin, Ticket } from 'lucide-react';

--- a/apps/web/src/pages/order-confirmation/index.tsx
+++ b/apps/web/src/pages/order-confirmation/index.tsx
@@ -1,7 +1,8 @@
 import { TropTixContext } from '@/components/AuthProvider';
 import { Spinner } from '@/components/ui/spinner';
 import { useFetchOrderById } from '@/hooks/useOrders';
-import { getDateFormatter, getFormattedCurrency } from '@/lib/utils';
+import { getDateFormatter } from '@/lib/dateUtils';
+import { getFormattedCurrency } from '@/lib/utils';
 import { Result, Table, Typography } from 'antd';
 import { ColumnsType } from 'antd/es/table';
 import Image from 'next/image';

--- a/apps/web/src/pages/order-details/index.tsx
+++ b/apps/web/src/pages/order-details/index.tsx
@@ -9,7 +9,8 @@ import {
   PostTicketType,
   useCreateTicket,
 } from '@/hooks/useTicket';
-import { getDateFormatter, getFormattedCurrency } from '@/lib/utils';
+import { getDateFormatter } from '@/lib/dateUtils';
+import { getFormattedCurrency } from '@/lib/utils';
 import { RedoOutlined } from '@ant-design/icons';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button, Drawer, List, Result, Typography, message } from 'antd';

--- a/apps/web/src/pages/orders/index.tsx
+++ b/apps/web/src/pages/orders/index.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from '@/components/ui/spinner';
 import { useFetchUserOrders } from '@/hooks/useOrders';
-import { getDateFormatter } from '@/lib/utils';
+import { getDateFormatter } from '@/lib/dateUtils';
 import { Button, Divider, Empty, Result } from 'antd';
 import Image from 'next/image';
 import Link from 'next/link';

--- a/apps/web/src/pages/tickets/index.tsx
+++ b/apps/web/src/pages/tickets/index.tsx
@@ -1,7 +1,7 @@
 import { TropTixContext } from '@/components/AuthProvider';
 import { Spinner } from '@/components/ui/spinner';
 import { GetOrdersType, useFetchOrderById } from '@/hooks/useOrders';
-import { getDateFormatter } from '@/lib/utils';
+import { getDateFormatter } from '@/lib/dateUtils';
 import { Button, Carousel, Divider, QRCode, Result } from 'antd';
 import JsPDF from 'jspdf';
 import Link from 'next/link';


### PR DESCRIPTION
This change moves all date-related utility functions into a new dateUtils.ts file to prevent unnecessary imports and execution of date-fns-tz in contexts where it's not needed.

Previously, importing any function from utils.ts (like cn) would also import date-fns-tz, which caused server-side errors in environments without full Intl time zone support.