### PR TITLE
Add tracked-docs layout + design system standardization plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,15 @@ apps/web/.env
 .vercel
 
 # Documentation
-docs/
+# docs/ is tracked. Use docs/private/ for personal notes you don't want committed.
+docs/private/
+
+# Pre-existing local-only plan docs (predate the tracked-docs convention).
+# Leave them where they are to stay private, or move them under docs/private/.
+docs/CREATE_TICKET_TYPE_PLAN.md
+docs/EDIT_TICKET_TYPE_PLAN.md
+docs/PROJECT_PLAN.md
+docs/event-form-refactor-plan.md
+docs/organizer-orders-plan.md
+docs/web-codebase-audit-and-plan.md
+docs/technical-roadmap.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+Conventions for Claude Code (and other AI agents) working in this repo.
+
+## Where artifacts live
+
+- **`docs/roadmap.md`** — the living strategic roadmap. Edited in place over time; priorities reflect the current view.
+- **`docs/adr/NNNN-<slug>.md`** — Architecture Decision Records. One decision per file, append-only, numbered sequentially. Use these to capture *why* a non-trivial choice was made.
+- **`docs/plans/YYYY-MM-<slug>.md`** — implementation plans for substantial initiatives. Front-matter status (`proposed`, `active`, `done`, `superseded`). The plan is the spec; an umbrella GitHub Issue tracks execution.
+- **`docs/audits/YYYY-MM-DD-<slug>.md`** — dated point-in-time audits and research snapshots. Frozen on write — never edited.
+- **`docs/private/`** — gitignored. Personal/working notes that should not be committed.
+- **`.claude/plans/`** — in-session scratch from plan mode. Not durable. Substantial plans get promoted into `docs/plans/`.
+
+## Issues vs docs
+
+- Docs answer **what / why / how**. Issues answer **who / when / status**.
+- Tasks, bugs, individual features → **GitHub Issues**.
+- A substantial initiative gets **one umbrella issue** (status + phase checklist) and **one plan doc** (spec + rationale). Implementation PRs reference the umbrella issue and the relevant plan.
+- Don't paste long structured plans into issue bodies — issues aren't diff-reviewable and rot as the plan evolves. Link to the doc.
+
+## Workflow
+
+- **Substantial work** (multi-PR initiative, architectural change, refactor across many files):
+  1. Write the plan to `docs/plans/YYYY-MM-<slug>.md` with front-matter (`status: proposed`).
+  2. Open a draft `Plan: …` PR for review. Reviewer approves the plan, not the implementation.
+  3. After approval, flip status to `active`, open the umbrella tracking issue with a phase checklist, begin implementation.
+  4. Each implementation PR references the umbrella issue (`Part of #N`) and the relevant phase.
+- **Durable decisions** made along the way → add an ADR.
+- **Trivial work** (typo, one-line fix, mechanical rename) → straight to a PR. No plan doc, no ADR.
+- **Unrelated cleanup spotted while doing other work** → open an issue (or use a spawn-task chip). Don't scope-creep the current PR.
+
+## Naming
+
+- ADRs: `NNNN-kebab-slug.md` (4-digit zero-padded, sequential).
+- Plans: `YYYY-MM-kebab-slug.md` (year-month, then slug).
+- Audits: `YYYY-MM-DD-kebab-slug.md` (full date, then slug).
+
+## ADR format
+
+```
+# N. Title
+
+- **Status:** Accepted | Proposed | Superseded by N
+- **Date:** YYYY-MM-DD
+
+## Context
+What's the situation that forced a decision?
+
+## Decision
+What did we decide?
+
+## Consequences
+What follows from this — good, bad, and trade-offs accepted.
+```
+
+## Plan front-matter
+
+```
+---
+title: <Initiative name>
+status: proposed | active | done | superseded
+created: YYYY-MM-DD
+tracking-issue: <#N or TBD>
+---
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# docs
+
+Project documentation. See [`CLAUDE.md`](../CLAUDE.md) at the repo root for the conventions agents follow when writing here.
+
+## Layout
+
+- [`roadmap.md`](./roadmap.md) — living strategic roadmap. What we're working on and why, in priority order.
+- [`adr/`](./adr) — Architecture Decision Records. One decision per numbered file with rationale and consequences.
+- [`plans/`](./plans) — implementation plans for substantial initiatives. Each plan has a status (`proposed`, `active`, `done`, `superseded`) and is typically paired with an umbrella tracking issue.
+- [`audits/`](./audits) — dated point-in-time audits and research snapshots. Frozen reference — never updated after the audit.
+- `private/` — local-only notes. Gitignored; not part of the tracked docs.

--- a/docs/adr/0001-tailwind-v4-first.md
+++ b/docs/adr/0001-tailwind-v4-first.md
@@ -1,0 +1,28 @@
+# 1. Upgrade Tailwind to v4 before the design-system color sweep
+
+- **Status:** Accepted
+- **Date:** 2026-06-02
+
+## Context
+
+`apps/web` runs Tailwind v3.3.3, but `apps/web/src/styles/globals.css` already contains a partially-applied v4 setup — a `@theme inline { … }` block sits in the file doing nothing (v3 ignores it). The block is a v4-shadcn token paste authored against the v4 CSS-first config model. Several practical consequences:
+
+- The shadow tokens (`--shadow-*`) and font variables defined in `globals.css` are never wired into the v3 JS config, so `shadow-md` / `font-sans` resolve to Tailwind defaults rather than the intended values.
+- Inter is loaded via `next/font` but applied via the class `font-inter`, which Tailwind never generates (no `fontFamily.inter` in the v3 config) — Inter likely isn't actually rendering.
+- The planned design-system standardization needs to consolidate ~570 raw palette colors onto semantic tokens; doing that on v3 means later redoing the foundation on v4.
+
+We considered three paths: stay on v3 and hand-wire fonts/shadows into the JS config; do the color sweep on v3 then upgrade later; or upgrade first.
+
+## Decision
+
+Upgrade to Tailwind v4 as the foundation of the design-system standardization, in its own PR, before the color migration. Move the theme config from `tailwind.config.ts` into CSS-first `@theme`, swap to `@tailwindcss/postcss`, replace `tailwindcss-animate` with `tw-animate-css`, and sweep the v4 utility renames (`shadow` → `shadow-sm`, `outline-none` → `outline-hidden`, opacity → slash syntax, `ring` default width, etc.). Use the official codemod (`npx @tailwindcss/upgrade`) as the starting point.
+
+Gate the upgrade on a browser-baseline check: v4 requires Safari 16.4+ / Chrome 111+ / Firefox 128+ (it uses `@property` and `color-mix()`). Confirm via PostHog that buyer browser mix supports this baseline on the checkout flow before committing.
+
+## Consequences
+
+- The orphan `@theme inline` block becomes the real config; the latent font and shadow tokens come online without any throwaway hand-wiring on v3.
+- The color-token sweep is built on the final system, not a legacy version we'd later re-migrate.
+- We accept v4's modern-browser baseline as a constraint for the consumer checkout flow, validated against analytics.
+- Token CSS variable format needs to be decided once during the upgrade: keep raw HSL channels and wrap inside `@theme` (`hsl(var(--primary))`), or convert to full HSL / OKLCH values (v4-shadcn default). We pick OKLCH or full HSL for cleanliness.
+- Future Tailwind upgrades (v5+) are easier from v4 than from v3.

--- a/docs/adr/0002-light-only-no-dark-toggle.md
+++ b/docs/adr/0002-light-only-no-dark-toggle.md
@@ -1,0 +1,25 @@
+# 2. Stay light-only; keep tokens dark-ready but ship no dark-mode toggle
+
+- **Status:** Accepted
+- **Date:** 2026-06-02
+
+## Context
+
+`apps/web/src/styles/globals.css` defines a complete `.dark` token set, and various components use `dark:` Tailwind variants. But the app has no theme toggle, no `next-themes` provider, no system-preference detection, and ~570 hardcoded palette colors that would break dark surfaces anyway. So dark mode is half-built: full token surface area, zero shipped UX, and broken-looking dark surfaces if it were ever enabled.
+
+We need to decide what the design-system standardization aims for: finish dark mode (build the toggle, make every surface dark-correct), drop it (remove the `.dark` tokens entirely), or hold.
+
+## Decision
+
+Stay light-only for now. The color migration onto semantic tokens proceeds and keeps surfaces *dark-ready* (because semantic tokens carry both light and dark values), but:
+
+- No theme toggle, no `next-themes`, no system-preference detection.
+- No new `dark:` variants; do not invest review time chasing dark-mode correctness.
+- The `.dark` token set stays in `globals.css` as-is — pre-paid optionality. We don't remove it and we don't expand on it.
+
+## Consequences
+
+- The standardization work is smaller and ships faster — we don't have to make every page render correctly in dark mode.
+- We can revisit dark mode later as a discrete project without re-doing the token work, because token-based components automatically respect whatever theme is mounted.
+- The codebase still contains some `dark:*` variants in components that were authored speculatively. They're inert in production (no `.dark` class is mounted), so leaving them is harmless and removing them is not worth the churn now.
+- Anyone shipping a one-off dark-themed surface (e.g., a marketing page) must use semantic tokens, not `dark:` variants, so it stays consistent with the rest of the app.

--- a/docs/adr/0003-indigo-canonical-brand.md
+++ b/docs/adr/0003-indigo-canonical-brand.md
@@ -1,0 +1,28 @@
+# 3. Indigo `--primary` is the canonical brand color
+
+- **Status:** Accepted
+- **Date:** 2026-06-02
+
+## Context
+
+The semantic token `--primary` is indigo (`238.73 83.53% 66.67%`) and is used throughout the shadcn component library — buttons, focus rings, badges, alerts. However the landing surfaces have drifted off-brand:
+
+- `apps/web/src/app/_components/hero.tsx` and `cta.tsx` use a cream background (`#faf8f4`, `#f7f4ec`) for the editorial hero.
+- `apps/web/src/styles/ant.css` styles the Ant Design carousel dots magenta (`#ff4ef6`).
+
+These were introduced via design iteration without being reconciled with the token-based primary. The standardization needs a single canonical brand identity to migrate onto.
+
+## Decision
+
+Treat indigo `--primary` as the canonical brand color. The landing-page cream and the carousel magenta are off-brand drift to consolidate, not parallel brand directions to preserve. Specifically:
+
+- Buttons, CTAs, focus rings, primary actions, and brand accents resolve to `--primary` (indigo).
+- The landing cream becomes either `background` / `muted` if it's incidental warmth, or a named `--surface-warm` token *only* if a warm hero is an intentional brand zone — that decision is made during the hero migration, not assumed in advance.
+- The carousel magenta is purely off-brand and is removed alongside the Ant Design removal.
+
+## Consequences
+
+- One brand color across the product reduces visual noise and simplifies future palette decisions.
+- The cream hero will visually shift toward indigo brand identity; that may or may not be the right direction. If the warmth is intentional, capturing it as a token is fine; if not, the hero gets re-skinned during the color migration phase.
+- Future re-brands change one token, not hundreds of usages.
+- Marketing/landing surfaces are explicitly *not* exempt from token discipline.

--- a/docs/plans/2026-06-design-system-standardization.md
+++ b/docs/plans/2026-06-design-system-standardization.md
@@ -1,0 +1,139 @@
+---
+title: Web Design System Standardization
+status: proposed
+created: 2026-06-02
+tracking-issue: "#277"
+---
+
+# Web Design System Standardization
+
+Audit findings, target standards spec, and phased refactor roadmap for `apps/web`. Decisions backing this plan are captured as ADRs: [Tailwind v4 first](../adr/0001-tailwind-v4-first.md), [light-only](../adr/0002-light-only-no-dark-toggle.md), [indigo canonical brand](../adr/0003-indigo-canonical-brand.md). Roadmap summary lives in [`roadmap.md`](../roadmap.md) under Priority 5.
+
+## Context
+
+`apps/web` already has a strong foundation — a shadcn/ui component set (Radix + CVA + `tailwind-merge`), a complete semantic HSL token set in `globals.css`, and `lucide-react` icons. But the design has **drifted away from that foundation**: most pages hand-roll raw Tailwind palette colors instead of using tokens, several config layers are inert or broken, and dead/vestigial code (a second header, Ant Design, legacy CSS) lingers.
+
+This document is the audit findings, the standards spec we're consolidating on, and a phased refactor roadmap.
+
+---
+
+## Current State (verified)
+
+**What's solid (keep):**
+- Semantic token set in `apps/web/src/styles/globals.css` (`--primary`, `--foreground`, `--muted`, `--border`, `--card`, `--destructive`, chart + sidebar tokens), correctly wired into `apps/web/tailwind.config.ts` via `hsl(var(--*))`.
+- `Button` is canonical — 47 import sites vs only 3 raw `<button>`. Good CVA variants in `apps/web/src/components/ui/button.tsx`.
+- `lucide-react` is the de-facto icon system (~60 sites); `sonner` is the single toast system.
+- `unified-header.tsx` is the live global header, wired in `apps/web/src/app/providers.tsx`. Organizer pages share a consistent `md:container px-4 py-8` layout.
+
+**Gaps & inconsistencies (fix):**
+
+1. **Color fragmentation — the headline problem.** **~572** raw palette-color utilities across `.tsx` bypass the token system. Two competing neutral ramps (`slate-*` *and* `gray-*`), ad-hoc `green-*` for success and `blue-*` for primary. Worst offenders: `apps/web/src/app/orders/[orderId]/receipt/page.tsx` (39), `apps/web/src/app/orders/[orderId]/confirmation/page.tsx` (33), loading skeletons, `apps/web/src/app/_components/cta.tsx` (29), `apps/web/src/components/ui/footer.tsx` (17), auth forms.
+
+2. **Inert / broken config:**
+   - A Tailwind **v4** `@theme inline { … }` block sits in `globals.css` inside a Tailwind **v3.3.3** project — entirely inert.
+   - `--shadow-*` and `--font-*` CSS vars are defined but **never wired** into the v3 config, so `shadow-md` / `font-sans` resolve to Tailwind defaults, not the tokens.
+   - Inter is loaded (`apps/web/src/components/AuthProvider.tsx`) but applied via `font-inter` — a **non-existent utility** (no `fontFamily.inter` in config), so Inter likely isn't actually rendering.
+   - Root wrapper hardcodes `text-gray-900` instead of `text-foreground`, anchoring the whole app off-token.
+
+3. **Dead / vestigial code:**
+   - `apps/web/src/components/ui/header.tsx` — **zero imports**, superseded by `unified-header.tsx`.
+   - Ant Design — only 4 files: an **empty** `ConfigProvider`, `Spin` (×2), and 2 icons (`apps/web/src/app/events/[eventId]/_components/tickets-checkout-forms.tsx`). Not a real dual-system — just removable.
+   - `apps/web/src/styles/buttons.css` — `.btn` used once (ErrorFallback); `apps/web/src/styles/ant.css` overrides target antd components that are likely no longer rendered.
+   - `.form-*` classes in `globals.css` hardcode `bg-white border-gray-300`.
+
+4. **Component-level token gaps:**
+   - `apps/web/src/components/ui/alert.tsx` `info` variant uses hardcoded `bg-blue-50 text-black border-blue-200`; no `success` / `warning` variants despite the toaster theming all four states.
+   - `apps/web/src/components/ui/spinner.tsx` is the only thing pulling in `antd` + `@ant-design/icons`.
+   - `apps/web/src/components/ui/logo.tsx` hardcodes the brand HSL inline.
+
+5. **Typography:** `apps/web/src/components/ui/typography.tsx` components are barely adopted (~4 sites) vs ~100+ raw `<h1 className="text-4xl …">`. The components use a `text` prop (not `children`), carry no color tokens, and `DividerWithText` misuses `text-white` on an `<hr>`. There's *also* a parallel `.h1` – `.h4` CSS class set in `globals.css` — a third heading system.
+
+6. **Layout:** public pages each pick their own max-width (`max-w-7xl`, `max-w-5xl`, `max-w-3xl`, `max-w-6xl`) and padding, while organizer pages consistently use `md:container px-4 py-8`. Spacing mixes `gap-3/4/6/8` and `space-y-4/6` with no scale.
+
+**Non-issues (confirmed, don't touch):** legacy `apps/web/src/pages/` is API-only (no UI); `DatePicker.tsx` is a legit composite over `calendar.tsx` (no antd DatePicker); mobile card components layer on `card.tsx` rather than duplicate it.
+
+---
+
+## Target Standards (the spec)
+
+### 1. Color — one source of truth: semantic tokens
+
+- **Rule:** UI colors come from semantic tokens only (`bg-background`, `text-foreground`, `text-muted-foreground`, `border-border`, `bg-card`, `bg-primary`, `text-destructive`, `bg-accent`). No raw `slate-*` / `gray-*` / `blue-*` / `green-*` in app code.
+- **Neutral ramp:** collapse both `slate-*` and `gray-*` onto `foreground` / `muted-foreground` / `border` / `muted` / `card`. Pick the token by *role*, not shade.
+- **Add missing semantic tokens:** introduce `--success` (replaces `green-*` for metrics / positive states) and `--warning`. This is the one *additive* token change.
+- **Brand:** indigo `--primary` is canonical (see [ADR 0003](../adr/0003-indigo-canonical-brand.md)).
+
+### 2. Typography — one system
+
+- Choose **one** heading approach. Recommendation: a single `cva`-based `<Heading level={1..4}>` / `<Text>` primitive using `children` (not a `text` prop) and tokens for color. Retire the `text`-prop `Typography*` components **and** the `.h1` – `.h4` CSS classes.
+- Body text defaults to `text-foreground`; secondary text to `text-muted-foreground`.
+
+### 3. Fonts / shadows / radius — wire via v4 `@theme`
+
+- Post-upgrade, define these in CSS `@theme inline` (the block that's currently inert): `--font-sans: var(--font-inter)` applied on `<html>` / `<body>`; delete the no-op `font-inter` class; drop unused Merriweather / JetBrains references.
+- Shadows (`--shadow-*`) and radius (`--radius`) become real tokens consumed natively by v4 — no hand-wiring into a JS config.
+- **Migration gotcha:** today the color vars store *raw HSL channels* (`238.73 83.53% 66.67%`) and the v3 config wraps them with `hsl(...)`. The orphan `@theme inline` maps `--color-primary: var(--primary)`, which would be invalid (no `hsl()` wrapper). On upgrade, decide once: either keep channel vars and wrap in `@theme` (`--color-primary: hsl(var(--primary))`), or convert vars to full color values (HSL or OKLCH, the v4-shadcn default). Pick OKLCH-or-full-HSL for cleanliness.
+
+### 4. Layout & spacing — standard page shell
+
+- **Rule:** every page wraps in the organizer pattern — `md:container px-4 py-8` (with a documented narrower inner `max-w-*` only for reading-width content like receipts). Migrate public pages off bespoke `max-w-7xl / 5xl / 3xl`.
+- **Spacing scale:** cards / related items `gap-4`; major sections `space-y-6`. Document the two values; avoid `gap-3/8` drift.
+
+### 5. Components — canonical set + cleanup
+
+- Keep the shadcn `ui/*` set as canonical. `Button`, `Card`, `Badge`, `Input`, `Form`, `Dialog`, `Select`, `Table` already token-clean.
+- Extend `alert.tsx` to token-based `default | destructive | success | warning | info` variants (matches toaster).
+- Add an `<EmptyState>` primitive (`icon, title, description, action`) — currently re-implemented per page.
+- Replace the antd `Spinner` with a lucide `Loader2`-based spinner so antd can be removed.
+
+### 6. Icons
+
+- `lucide-react` only. Replace `@ant-design/icons` (`Minus` / `Plus` / `LoadingOutlined`) with lucide equivalents; replace inline SVG sort icons in `data-table.tsx`.
+
+---
+
+## Roadmap (phased)
+
+**Phase 0 — Tailwind v4 upgrade (own PR, foundation).** See [ADR 0001](../adr/0001-tailwind-v4-first.md).
+- **Pre-check (gating):** confirm buyer browser mix supports v4's baseline (Safari 16.4+ / Chrome 111+ / Firefox 128+) via PostHog analytics, especially on the checkout flow. If a meaningful slice is older, reconsider before proceeding.
+- Run `npx @tailwindcss/upgrade` (handles `@tailwind` → `@import "tailwindcss"`, config → CSS, template utility renames).
+- Invert config to CSS-first: move the `tailwind.config.ts` color/radius mapping into `@theme` in `globals.css`; fix the token var format per §3 so `@theme inline` resolves; remove the inert/duplicate block.
+- Build chain: swap to `@tailwindcss/postcss` (drop `autoprefixer` + manual import handling — Lightning CSS covers both); replace `tailwindcss-animate` → `tw-animate-css`.
+- Sweep v4 breaking renames in templates the codemod can't fully infer: shadow scale (`shadow` → `shadow-sm`, `shadow-sm` → `shadow-xs`), `ring` default width, `outline-none` → `outline-hidden`, opacity-utility → slash syntax. The global `* { @apply border-border }` already neutralizes the gray-200 → currentColor default-border change.
+- This phase *also* closes the font-wiring and shadow-wiring findings natively.
+
+**Phase 1 — Dead code & vestigial deps.** Delete `header.tsx`; remove Ant Design end-to-end (`ConfigProvider`, `Spin` → lucide `Loader2` spinner, antd icons → lucide, drop `antd` + `@ant-design/icons` deps, delete `ant.css` + the antd overrides in `buttons.css`); migrate ErrorFallback off `.btn` to `Button` and delete `buttons.css`; fix the root wrapper `text-gray-900` → `text-foreground`; convert `.form-*` classes to tokens or delete in favor of `Input`.
+
+**Phase 2 — Neutral ramp consolidation.** Migrate `slate-*` and `gray-*` → semantic tokens. Biggest bang: receipt, confirmation, loading skeletons, footer, auth.
+
+**Phase 3 — Semantic color migration.** Add `--success` / `--warning` tokens (in `@theme`); migrate `green-*` → `success`, stray `blue-*` → `primary`, reds → `destructive`. Consolidate landing cream / magenta onto tokens.
+
+**Phase 4 — Typography + layout primitives.** Ship the single `Heading` / `Text` primitive; retire the other two heading systems. Introduce the standard page shell + spacing scale; migrate public pages.
+
+**Phase 5 — Component polish.** Token-based `alert` variants (`default | destructive | success | warning | info`); `<EmptyState>`; tokenize `logo.tsx`; finish data-table icon swap.
+
+**Phase 6 — Guardrails.** Add an ESLint / Tailwind lint rule (`eslint-plugin-tailwindcss` + a custom restricted-pattern rule) banning raw palette colors in `src/**`, so drift can't recur. Document the standard in a short reference doc.
+
+Phase 0 must land first (everything builds on the v4 token base). Phase 1 is independent. Phases 2–3 are the bulk color sweep; 4+ build on the token base.
+
+---
+
+## Critical files
+
+- **Config / tokens / build:** `apps/web/tailwind.config.ts`, `apps/web/src/styles/globals.css`, `apps/web/postcss.config.js`, `apps/web/package.json` (deps swap in Phase 0), `apps/web/src/styles/ant.css`, `apps/web/src/styles/buttons.css`
+- **Wiring:** `apps/web/src/app/providers.tsx`, `apps/web/src/components/AuthProvider.tsx`, `apps/web/src/app/layout.tsx`
+- **Components to change:** `apps/web/src/components/ui/alert.tsx`, `spinner.tsx`, `typography.tsx`, `logo.tsx`, `data-table.tsx`
+- **Delete:** `apps/web/src/components/ui/header.tsx`
+- **Heaviest color migration:** `apps/web/src/app/orders/[orderId]/receipt/page.tsx`, `apps/web/src/app/orders/[orderId]/confirmation/page.tsx`, `apps/web/src/app/_components/cta.tsx`, `apps/web/src/app/_components/hero.tsx`, `apps/web/src/components/ui/footer.tsx`, auth `_components/`
+
+## Verification (per phase, before merge)
+
+- `cd apps/web && yarn typecheck && yarn lint && yarn build` clean.
+- **Phase 0 (v4):** build succeeds on the new engine; diff the rendered output visually against pre-upgrade — pay attention to shadows, ring widths, and borders (the utilities that changed semantics). Confirm Inter actually renders now (inspect computed `font-family` on `<body>`). Confirm `@theme` tokens resolve (`bg-primary` is indigo, not transparent).
+- Visual smoke (golden path) of each surface in `next dev`: homepage, events list, event detail + ticket modal, checkout / confirmation / receipt, organizer dashboard + event management, auth. Confirm fonts, primary CTAs, cards, badges, and loading / empty states render correctly.
+- Track the count down: `grep -rEoh "(bg|text|border|ring)-(gray|slate|zinc|blue|green|red|...)-[0-9]{2,3}" --include="*.tsx" src | wc -l` should trend toward ~0 in app code by end of Phase 3.
+- After antd removal: `grep -r "antd" src` returns nothing; `antd` / `@ant-design/icons` gone from `package.json`.
+
+## Out of scope (this pass)
+
+Dark-mode toggle (see [ADR 0002](../adr/0002-light-only-no-dark-toggle.md)); `apps/backstage` and `apps/organizer` (mobile); `apps/web/src/pages/` API routes; any redesign of brand identity beyond consolidating onto the existing indigo token (see [ADR 0003](../adr/0003-indigo-canonical-brand.md)).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,267 @@
+# TropTix Technical Roadmap
+
+## Why This Document Exists
+
+TropTix is live and serving real events. As we grow, several issues in the codebase need to be addressed — some are bugs that directly affect revenue and trust, others are structural changes that will make the platform more reliable and easier to build on. This document lays out every planned change, why it matters, and the order we should tackle them.
+
+---
+
+## Priority 1 — Critical Bug Fixes
+
+These are issues in the live system that can lose us money or break trust with organizers and attendees. No architectural changes required — just targeted fixes to existing code.
+
+### 1.1 Two people can buy the last ticket at the same time
+
+**The problem:** When someone checks out, the system reads the available ticket count, confirms there's stock, and creates the order. But if two buyers hit checkout at the exact same moment, they both read the same count, both see "1 remaining," and both get through. We've sold a ticket that doesn't exist.
+
+**Why it matters:** Overselling means we either have to cancel a paid customer's order (terrible experience, potential chargeback) or allow more people into a venue than capacity permits (liability issue). This is especially likely during high-demand on-sale moments.
+
+**The fix:** Add database-level locking so that checkout requests for the same ticket type are processed one at a time, not in parallel.
+
+---
+
+### 1.2 Payment confirmation can partially fail
+
+**The problem:** When Stripe tells us a payment succeeded, we update the order status, update each ticket's status, and increment the sold count for each ticket type — but these are separate database operations. If one fails partway through (e.g., a network blip), some ticket types get updated and others don't. The data is now inconsistent.
+
+**Why it matters:** Inconsistent data means our inventory counts drift from reality. An organizer might see "50 sold" when the real number is 48 or 52. Over time this erodes trust in the dashboard numbers and can cause overselling or underselling.
+
+**The fix:** Wrap all payment confirmation database updates in a single transaction — either everything succeeds or nothing does.
+
+---
+
+### 1.3 Stripe API version mismatch
+
+**The problem:** Different parts of our code talk to Stripe using different API versions (2020, 2023, and 2024). Stripe changes the shape of its responses between versions, so the data we send to Stripe in checkout might look different from what we expect to receive back in the webhook.
+
+**Why it matters:** This can cause subtle, hard-to-debug issues — fields missing or renamed between versions. It's a ticking time bomb that will eventually cause a payment to not be recorded correctly.
+
+**The fix:** Create a single shared Stripe client with one pinned API version used everywhere.
+
+---
+
+## Priority 2 — Database Redesign
+
+These changes restructure our data model to be cleaner, more accurate, and ready for future features. We should do these after the bug fixes above, so we don't have to rewrite the fix code.
+
+### 2.1 Remove unused tables
+
+**What:** Delete the `SocialMediaAccounts`, `DelegatedUsers`, and `Promotions` tables.
+
+**Why:** These tables are defined in the database but aren't used by any live feature. Keeping dead schema around adds confusion when reading the codebase and increases the surface area we have to maintain during migrations.
+
+---
+
+### 2.2 Standardize table names
+
+**What:** Rename all tables from plural to singular form — `Users` → `User`, `Events` → `Event`, `Orders` → `Order`.
+
+**Why:** Consistency. Singular names are the industry convention for database models (each row is one User, not many Users). This also makes the code read more naturally everywhere we query the database.
+
+---
+
+### 2.3 Clarify ticket model naming
+
+**What:** Rename `TicketTypes` → `EventTicket` (the ticket offerings an organizer creates) and `Tickets` → `OrderTicket` (the actual tickets someone buys in an order).
+
+**Why:** "TicketTypes" vs "Tickets" is confusing — both sound like they could be the same thing. `EventTicket` (what's for sale) vs `OrderTicket` (what was purchased) immediately communicates the distinction to anyone reading the code or the database.
+
+---
+
+### 2.4 Move order type to the order level
+
+**What:** Remove the FREE/PAID/COMPLEMENTARY designation from individual tickets and add it as a `type` field on the Order instead.
+
+**Why:** Whether a transaction is free, paid, or complementary is a property of the whole order, not each ticket line item. Storing it per-ticket is redundant and forces unnecessary conditional logic throughout the checkout code.
+
+---
+
+### 2.5 Meaningful ticket statuses
+
+**What:** Replace the current ticket statuses (`AVAILABLE` / `NOT_AVAILABLE`) with `VALID`, `USED`, `CANCELLED`, and `REFUNDED`.
+
+**Why:** The current statuses are confusing and overloaded. `NOT_AVAILABLE` currently means "payment hasn't been confirmed yet" during checkout but "this ticket was already scanned" at the door. There's also no way to distinguish a refunded ticket from one that was never paid for. The new statuses map directly to the real lifecycle of a ticket.
+
+---
+
+### 2.6 Rename discount code to password
+
+**What:** Rename the `discountCode` field on ticket offerings to `password`.
+
+**Why:** This field is used to gate access to password-protected ticket types (e.g., VIP tickets that only people with the code can see). Calling it "discountCode" is misleading — it doesn't apply a discount, it unlocks visibility. The name should match what it actually does.
+
+---
+
+### 2.7 Remove redundant name fields
+
+**What:** Drop the `name` field from both the Order and User tables, keeping only `firstName` and `lastName`.
+
+**Why:** Both tables already have `firstName` and `lastName`. The extra `name` field is redundant, sometimes out of sync, and creates ambiguity about which one is the source of truth.
+
+---
+
+### 2.8 Rename organizer to host name
+
+**What:** Rename the `organizer` field on Events to `hostName`.
+
+**Why:** `organizer` looks like it should be a reference to an organizer record, but it's actually just a display name string. `hostName` makes it immediately clear this is a label, not a relation.
+
+---
+
+### 2.9 Make audit timestamps mandatory
+
+**What:** Ensure `createdAt` and `updatedAt` are required (non-nullable) on every table.
+
+**Why:** On the Orders table, `createdAt` is currently optional. Our cleanup job compares against `createdAt` to find expired orders — if it's ever null, that order could slip through the cracks. Audit timestamps should never be missing.
+
+---
+
+### 2.10 Simplify date and time fields
+
+**What:** Collapse the split date/time fields into single DateTime fields. On Events: `startDate` + `startTime` + `endDate` + `endTime` become `startsAt` and `endsAt`. On ticket offerings: same pattern becomes `saleStartsAt` and `saleEndsAt`.
+
+**Why:** Having date and time in separate columns forces every piece of code that needs the actual moment to merge them together — and some places don't bother (our sale window check currently ignores the time columns entirely, meaning a ticket set to go on sale at 10am is actually available at midnight). A single DateTime field is what the database stores natively and eliminates this class of bugs.
+
+---
+
+### 2.11 Track when attendees check in
+
+**What:** Add a `checkinTimestamp` field on each purchased ticket (OrderTicket).
+
+**Why:** When a ticket is scanned at the door, we currently flip a status flag but don't record *when* it happened. Without timestamps, organizers can't see check-in patterns (e.g., "80% of attendees arrived in the first hour"), and we have no audit trail for disputes ("I was there on time but they said I wasn't").
+
+---
+
+### 2.12 Store money as whole cents
+
+**What:** Change all price fields from decimal (Float) to integer cents. `$19.99` is stored as `1999`.
+
+**Why:** Floating-point math causes rounding errors with currency. `$19.99 * 3` can equal `$59.96999...` in floating point. Our code already has workarounds for this (`Math.round`, `parseFloat(...toFixed(2))`) — storing in cents eliminates the problem at the source and removes those hacks. This is how Stripe stores money, so it also eliminates conversion bugs.
+
+---
+
+### 2.13 Compute availability instead of tracking a counter
+
+**What:** Remove the `quantitySold` counter from ticket offerings. Instead, calculate availability by counting actual purchased tickets with active (non-cancelled) orders.
+
+**Why:** The counter is the root cause of bug 1.1 — it drifts whenever the cleanup job or payment webhook partially fails. Counting real records is always accurate because it's the source of truth. Our checkout code already partially does this (it counts pending and completed tickets); we just need to make it the only method and remove the counter.
+
+---
+
+## Priority 3 — Codebase Cleanup
+
+Quality-of-life improvements for development speed and reliability. Can be done alongside or after the schema work.
+
+### 3.1 Remove Ant Design dependency
+
+**What:** Replace the one Ant Design spinner component with a simple Tailwind CSS spinner. Uninstall `antd` and `@ant-design/icons`.
+
+**Why:** We use Ant Design for exactly one component (a loading spinner), but it pulls in 30+ sub-packages into our bundle. This bloats our install size, slows builds, and increases the JavaScript shipped to users' browsers. Every other component already uses our Tailwind-based UI library.
+
+---
+
+### 3.2 Eliminate dual routing
+
+**What:** Move the Stripe webhook from the legacy Pages Router (`src/pages/`) to the App Router (`src/app/`). Delete the `src/pages` directory entirely.
+
+**Why:** Running both Next.js routers simultaneously causes confusing behavior, prevents full adoption of modern Next.js features, and means we have two different patterns for the same thing. The only file keeping the Pages Router alive is the Stripe webhook — once moved, we can delete the entire legacy directory.
+
+---
+
+### 3.3 Remove unsafe type annotations
+
+**What:** Replace ~21 instances of `any` types with proper TypeScript types and enable strict `noImplicitAny`.
+
+**Why:** `any` disables TypeScript's ability to catch bugs at compile time. Several of these are in critical paths — the order helper functions accept untyped parameters, meaning you could pass the wrong data shape and TypeScript wouldn't warn you. Fixing these makes refactoring safer and onboarding faster.
+
+---
+
+### 3.4 Validate all API inputs
+
+**What:** Add Zod schema validation to every API route. Currently none of our 11 API routes validate incoming request data on the server.
+
+**Why:** Without server-side validation, malformed or malicious requests hit the database directly. This can cause cryptic error messages, unexpected behavior, or in the worst case, data corruption. Validation is especially important for the checkout route where money is involved.
+
+---
+
+### 3.5 Add database indexes
+
+**What:** Add indexes on frequently queried columns: order status, ticket status, and organizer user ID on events.
+
+**Why:** As events grow, queries that filter by status (the cleanup job, availability checks, dashboard queries) will slow down without indexes. Adding them now is trivial; adding them after performance degrades means firefighting.
+
+---
+
+## Priority 4 — Future Migrations
+
+These are larger architectural shifts to plan as separate projects once the above work stabilizes the current system.
+
+### 4.1 Prisma → Drizzle ORM
+
+Move from Prisma to Drizzle for database management. Drizzle gives us better control over database transactions (needed for the locking patterns in bug 1.2), native support for Postgres functions, and keeps schema definitions, queries, and migrations all in TypeScript. We should do this after the schema redesign is complete so we migrate to Drizzle with a clean data model.
+
+### 4.2 Firebase → Supabase Authentication
+
+Replace Firebase Authentication with Supabase Auth. This eliminates the custom JWT cookie bridge that causes auth flickering on page load (the full-screen spinner users see), removes the extra API call needed to check if a user is an organizer, and integrates natively with our Postgres database. Supabase Auth also comes included in our existing Supabase plan at no additional cost.
+
+### 4.3 Reservation-based checkout
+
+Replace the current checkout flow (create a full order upfront, clean up if abandoned) with a lightweight reservation system. A database function atomically reserves tickets with a time limit, and orders are only created after payment succeeds. This is the industry-standard approach for ticket inventory and completely eliminates the race conditions described in bugs 1.1–1.3. Depends on the Drizzle migration for Postgres function support.
+
+### 4.4 Transactional email queue
+
+Add a database-backed email queue instead of sending emails inline during request handling. Currently, if the email provider is slow or fails during checkout, it either delays the user's response or silently drops the confirmation email. A queue decouples email delivery from the checkout flow and enables automatic retries. Not urgent until we're processing ~50+ orders per hour during peak events.
+
+---
+
+## Priority 5 — Design System Standardization (Web)
+
+The web app (`apps/web`) already has a solid foundation: a shadcn/ui component library, a complete set of semantic design tokens (brand color, text, background, border, etc.), Lucide icons, and a single toast system. The problem is **drift away from that foundation**, not its absence. Most pages hand-roll raw Tailwind colors instead of using the tokens (~570 instances, including two competing "gray" palettes used interchangeably), several styling config layers are inert or broken, and some dead/duplicate code lingers. The result is a UI that looks subtly inconsistent across the homepage, event pages, checkout, and organizer dashboard, and that is hard to restyle or theme because there is no single source of truth.
+
+The goal is one color system (semantic tokens), one typography system, one standard page layout, a clean canonical component set, and an automated guardrail so the drift can't come back. Decisions made up front: stay **light-only** for now (we keep tokens theme-ready but won't build a dark-mode toggle yet); treat the existing **indigo brand color as canonical** (the stray cream/magenta on the landing pages is off-brand drift to consolidate); and **upgrade Tailwind to v4 first** as the foundation. These should be done after — or in parallel with — the bug and schema work; none of it touches revenue paths directly, but it makes every future feature faster to build and visually consistent.
+
+### 5.1 Upgrade to Tailwind v4 (foundation)
+
+**What:** Upgrade from Tailwind v3.3 to v4 as a standalone first step, using the official upgrade tool. Move the theme config out of the JavaScript config file and into CSS (v4's model), swap the build plugin (`@tailwindcss/postcss`, dropping `autoprefixer`), and replace `tailwindcss-animate` with its v4 equivalent.
+
+**Why:** The codebase already contains a half-applied v4 setup — a v4-style theme block sits in our CSS today but does nothing because we're still on v3. Upgrading makes that block real and, in one move, fixes three latent problems: our font (Inter) isn't actually being applied because it's wired to a class Tailwind never generated; our shadow tokens are defined but never connected; and the theme block is dead. Doing the upgrade first means the later color work is built on the final system, not redone later. One thing to verify before committing: v4 requires modern browsers (Safari 16.4+, Chrome 111+, Firefox 128+) — we should confirm our buyers' browser mix supports this, especially on checkout.
+
+---
+
+### 5.2 Remove dead code and finish the Ant Design removal
+
+**What:** Delete the unused second header component, the legacy button CSS (used in exactly one place), and the empty Ant Design config wrapper. Replace the one remaining Ant Design spinner with a Lucide/Tailwind spinner and uninstall `antd` + `@ant-design/icons`. This completes and expands Priority 3.1.
+
+**Why:** These are leftovers that confuse anyone reading the code and, in Ant Design's case, bloat the bundle with 30+ sub-packages for a single spinner. Clearing them shrinks the surface area before the color migration so we're not migrating code that's about to be deleted.
+
+---
+
+### 5.3 Consolidate all colors onto design tokens
+
+**What:** Replace the ~570 raw Tailwind color utilities (e.g. `text-slate-500`, `bg-gray-100`, `text-green-600`) with semantic tokens (`text-muted-foreground`, `bg-muted`, etc.). Collapse the two competing neutral palettes (`slate-*` and `gray-*`) onto one token set, add `success` and `warning` tokens to cover the states we currently express with raw greens and yellows, and fold the off-brand landing-page colors back to brand tokens. This is the largest item and runs in two passes: neutrals first, then semantic states.
+
+**Why:** This is the headline inconsistency. Because colors are hardcoded everywhere, the same "muted gray" is expressed three different ways across pages, and changing the brand or fixing contrast means hunting through hundreds of files. Routing everything through tokens gives us one place to adjust the look, guarantees consistency across surfaces, and keeps the app theme-ready for the future.
+
+---
+
+### 5.4 Unify typography and page layout
+
+**What:** Replace the three overlapping heading systems (a barely-used component, a parallel set of CSS classes, and ad-hoc inline styles) with a single heading/text primitive that uses tokens. Standardize every page on one container/spacing pattern (the one the organizer pages already use) instead of each page picking its own width and padding.
+
+**Why:** Right now headings are styled inconsistently and public pages each invent their own max-width and spacing, so the homepage, event page, and checkout don't line up visually. One typography primitive and one page shell make new pages automatically consistent and remove a recurring source of guesswork.
+
+---
+
+### 5.5 Polish the shared components
+
+**What:** Round out the canonical component set: give the alert component proper token-based variants (success/warning/info/error to match the toast system), add a reusable empty-state component (currently re-implemented on every page), tokenize the hardcoded brand color in the logo, and finish moving the last icons (including inline SVGs in the data table) to Lucide.
+
+**Why:** These are the small inconsistencies users feel without being able to name them — an "info" alert that's a different blue than everything else, empty states that look slightly different on each page. Standardizing them is the finishing layer on top of the token work.
+
+---
+
+### 5.6 Add a guardrail against future drift
+
+**What:** Add a lint rule that bans raw Tailwind palette colors in application code, and write a short design-system reference doc covering the tokens, the typography primitive, and the standard page layout.
+
+**Why:** Without enforcement, the drift we're fixing here will simply creep back the next time someone reaches for `bg-gray-100` out of habit. A lint rule catches it at the point of writing, and the reference doc gives everyone the sanctioned way to do it instead.


### PR DESCRIPTION
## Summary

- Establish a tracked-docs layout (`docs/roadmap.md`, `docs/adr/`, `docs/plans/`, `docs/audits/`) so planning artifacts live in the repo and are reviewable via PRs instead of being stuck in a fully-gitignored `docs/` folder.
- Add `CLAUDE.md` at the repo root capturing the conventions agents follow when writing in `docs/` (where things go, naming, workflow, ADR / plan format, issues-vs-docs boundary).
- Migrate `technical-roadmap.md` to the new `docs/roadmap.md`, including a new **Priority 5 — Design System Standardization (Web)**.
- Seed the new layout with the design-system initiative: full plan in `docs/plans/2026-06-design-system-standardization.md` plus three ADRs capturing the direction decisions.
- Pre-existing local-only plan docs (`CREATE_TICKET_TYPE_PLAN.md`, etc.) stay private via explicit per-file `.gitignore` rules — not promoted in this PR.

Tracking issue: #277

## What's in this PR

- `CLAUDE.md` — repo-level conventions for AI agents
- `.gitignore` — `docs/` → `docs/private/` plus per-file ignores for legacy local plan docs
- `docs/README.md` — index
- `docs/roadmap.md` — migrated roadmap with Priority 5 added
- `docs/plans/2026-06-design-system-standardization.md` — full plan, audit findings, target standards, phased roadmap
- `docs/adr/0001-tailwind-v4-first.md` — upgrade Tailwind v4 first as foundation
- `docs/adr/0002-light-only-no-dark-toggle.md` — stay light-only; tokens dark-ready, no toggle
- `docs/adr/0003-indigo-canonical-brand.md` — indigo \`--primary\` is canonical brand

## Why now

Up to this point, every plan / audit / roadmap edit was made in a fully-gitignored folder, so:
- Nothing survived PR review.
- Nothing synced across machines.
- There was no clean place to capture *decisions* (ADRs) separately from one-off implementation plans.

This PR sets up the system once so future Claude Code sessions (and humans) write into a consistent, reviewable layout.

## What this PR is *not*

- **Not** code changes to \`apps/web\`. This is planning artifacts only — the design-system implementation happens in follow-up PRs phased per the plan, gated on the issue checklist.
- **Not** a migration of every existing local doc. Those stay private until you triage them.

## Reviewer focus

Read in this order for context:
1. \`CLAUDE.md\` — does the convention work for you?
2. \`docs/roadmap.md\` Priority 5 — does the summary track?
3. \`docs/plans/2026-06-design-system-standardization.md\` — the full plan / spec.
4. The three ADRs — do the decisions match what we agreed in the session?

## Test plan

- [ ] Roadmap and plan render correctly on GitHub.
- [ ] \`.gitignore\` still hides the legacy local plan docs after pull (\`git status\` should not list them).
- [ ] Umbrella tracking issue #277 references resolve.