### PR TITLE
Checkout rebuild (1/6): single shared Stripe client

### DIFF
--- a/apps/web/src/app/api/checkout/initiate/route.ts
+++ b/apps/web/src/app/api/checkout/initiate/route.ts
@@ -2,7 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies, headers } from 'next/headers'; // For reading cookies in App Router
 import prisma from '@/server/prisma';
-import Stripe from 'stripe';
+import { stripe } from '@/server/lib/stripe';
 import { UserDetailsFormData } from '@/lib/schemas/checkoutSchema'; // Adjust path if needed
 import { OrderStatus, TicketFeeStructure, TicketStatus } from '@prisma/client';
 import { getFirebaseAdmin } from '@/server/lib/firebaseAdmin'; // Adjust path if needed
@@ -16,10 +16,6 @@ import {
 import { calculateFees } from '@/lib/fees'; // Adjust path if needed
 import { Prisma } from '@prisma/client';
 import { sendEmailConfirmationEmailToUser } from '@/server/lib/email';
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  // @ts-ignore
-  apiVersion: '2024-04-10',
-});
 
 interface InitiateRequestData {
   eventId: string;

--- a/apps/web/src/pages/api/stripe/index.ts
+++ b/apps/web/src/pages/api/stripe/index.ts
@@ -1,13 +1,7 @@
 import { VercelRequest, VercelResponse } from '@vercel/node';
-import Stripe from 'stripe';
 import { allowCors } from '@/server/lib/auth';
 import prisma from '@/server/prisma';
-
-const secretKey = process.env.STRIPE_SECRET_KEY as string;
-const stripe = new Stripe(secretKey, {
-  // @ts-ignore
-  apiVersion: '2023-08-16',
-});
+import { stripe, MOBILE_STRIPE_API_VERSION } from '@/server/lib/stripe';
 
 async function handler(request: VercelRequest, response: VercelResponse) {
   const { method } = request;
@@ -96,7 +90,7 @@ async function createCharge(body, response) {
 
     const ephemeralKey = await stripe.ephemeralKeys.create(
       { customer: customerId },
-      { apiVersion: '2020-08-27' }
+      { apiVersion: MOBILE_STRIPE_API_VERSION }
     );
 
     const paymentIntent = await stripe.paymentIntents.create({

--- a/apps/web/src/pages/api/stripe/webhook.ts
+++ b/apps/web/src/pages/api/stripe/webhook.ts
@@ -5,6 +5,7 @@ import {
   updateTicketTypeQuantitySold,
 } from '@/server/lib/orderHelper';
 import prisma from '@/server/prisma';
+import { stripe } from '@/server/lib/stripe';
 import { buffer } from 'micro';
 
 import { sendEmailConfirmationEmailToUser } from '@/server/lib/email';
@@ -15,11 +16,6 @@ export const config = {
     bodyParser: false,
   },
 };
-
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  // @ts-ignore
-  apiVersion: '2023-08-16',
-});
 
 const endpointSecret = process.env.STRIPE_CHARGE_SUCCEEDED_WEBHOOK;
 

--- a/apps/web/src/server/lib/stripe.ts
+++ b/apps/web/src/server/lib/stripe.ts
@@ -1,0 +1,22 @@
+import Stripe from 'stripe';
+
+/**
+ * Single shared Stripe client for all server-side Stripe calls.
+ *
+ * Pinned to the API version bundled with the installed `stripe` SDK
+ * (`Stripe.LatestApiVersion`), so the type matches and no `@ts-ignore` is
+ * needed. Import this everywhere instead of constructing `new Stripe(...)`
+ * with ad-hoc versions — divergent versions are the root of roadmap bug 1.3.
+ */
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: '2023-10-16',
+});
+
+/**
+ * Stripe API version used when minting ephemeral keys for the mobile app.
+ *
+ * This must match the Stripe SDK version embedded in the mobile client, NOT
+ * the server API version above — do not unify it with `stripe`'s apiVersion.
+ * Confirm against the mobile app's Stripe SDK before changing.
+ */
+export const MOBILE_STRIPE_API_VERSION = '2020-08-27';

--- a/docs/adr/0004-reservation-based-checkout.md
+++ b/docs/adr/0004-reservation-based-checkout.md
@@ -1,0 +1,35 @@
+# 4. Reservation-based checkout on the current stack
+
+- **Status:** Proposed
+- **Date:** 2026-06-02
+
+## Context
+
+The roadmap's three Priority-1 bugs are not independent defects — they share one root cause, the inventory accounting model:
+
+- **1.1 Overselling:** availability is read, checked, then written in separate steps with no atomic guard, so concurrent checkouts both pass the stock check.
+- **1.2 Partial payment confirmation:** the Stripe webhook applies the order-status update and the per-ticket-type `quantitySold` increments as separate, non-transactional writes.
+- **1.3 Stripe drift:** three clients on three API versions — a symptom of organic growth around the same flow.
+
+Underneath all three: a mutable `quantitySold` counter incremented in two places and never decremented on expiry; a PENDING `Orders` row used as an implicit reservation; availability computed by counting order rows in one place and read from the counter in another (two disagreeing sources of truth); and a 5-minute expiry cron that releases no inventory.
+
+Three options were considered:
+
+1. **Surgical patches** — add a `SELECT … FOR UPDATE` lock (1.1), wrap the webhook in a transaction (1.2), share one Stripe client (1.3). Stops the bleeding fastest, but the lock patch is throwaway the moment a reservation model lands, and the two-sources-of-truth problem remains.
+2. **Wait for the Drizzle/Supabase migration** ([[0001]]–[[0003]] cover the design-system track; the architecture migration is tracked separately) and rebuild checkout there. Correct destination, but leaves a live revenue bug unfixed for months behind a large migration.
+3. **Rebuild the checkout/inventory/payment subsystem now**, as the reservation model, in place on the current Prisma + Postgres stack.
+
+## Decision
+
+Take option 3. Replace the inventory model with a reservation-based design **now, on Prisma + Postgres**, using raw SQL and Postgres functions for the concurrency-critical operations (`reserve`, `confirm`, `release`, `expire`). General-admission **counter inventory** (`capacity` / `reserved` / `sold`) with an atomic conditional decrement (`UPDATE … WHERE capacity - reserved - sold >= n`); an explicit `Reservation` with a TTL; orders materialized only on payment success; an idempotent, atomic webhook as the single source of truth. Fold in only the schema corrections the checkout functionally depends on (integer cents, `startsAt`/`endsAt`, meaningful ticket statuses, order-level type, non-null `createdAt`).
+
+This is consistent with the stated target architecture principle — *Drizzle for 90% CRUD, Postgres functions for concurrency-critical operations.* Authoring those functions on Prisma now makes the later Drizzle migration mechanical (the functions are stack-agnostic SQL).
+
+Assigned seating (per-unit inventory rows + `FOR UPDATE SKIP LOCKED`) is explicitly **not** built — events are general-admission only for the foreseeable future.
+
+## Consequences
+
+- **Good:** all three P1 bugs are eliminated structurally, not patched. One source of truth for availability. Forward-compatible with the Drizzle/Supabase migration. No throwaway lock code.
+- **Trade-off:** larger change than three patches, touching the schema. Mitigated by phasing into four reviewable PRs (additive migration → checkout cutover → organizer reads → cleanup) and by deploying the cutover in a low-traffic window.
+- **Risk accepted:** the in-place cutover must seed the `reserved` counter from in-flight PENDING holds at switch time. Done in place (not strangler/parallel-run) per owner decision, with a brief checkout pause during the seed+switch.
+- **Deferred:** Drizzle (P4.1), Supabase Auth (P4.2), webhook → App Router (P3.2), full transactional email service (P4.4 — a minimal outbox only), Stripe Connect, and cosmetic table/field renames.

--- a/docs/adr/0007-reservation-based-checkout.md
+++ b/docs/adr/0007-reservation-based-checkout.md
@@ -1,4 +1,4 @@
-# 4. Reservation-based checkout on the current stack
+# 7. Reservation-based checkout on the current stack
 
 - **Status:** Proposed
 - **Date:** 2026-06-02
@@ -23,7 +23,7 @@ Three options were considered:
 
 Take option 3. Replace the inventory model with a reservation-based design **now, on Prisma + Postgres**, using raw SQL and Postgres functions for the concurrency-critical operations (`reserve`, `confirm`, `release`, `expire`). General-admission **counter inventory** (`capacity` / `reserved` / `sold`) with an atomic conditional decrement (`UPDATE … WHERE capacity - reserved - sold >= n`); an explicit `Reservation` with a TTL; orders materialized only on payment success; an idempotent, atomic webhook as the single source of truth. Fold in only the schema corrections the checkout functionally depends on (integer cents, `startsAt`/`endsAt`, meaningful ticket statuses, order-level type, non-null `createdAt`).
 
-This is consistent with the stated target architecture principle — *Drizzle for 90% CRUD, Postgres functions for concurrency-critical operations.* Authoring those functions on Prisma now makes the later Drizzle migration mechanical (the functions are stack-agnostic SQL).
+All schema and function changes ship through the Supabase migrations pipeline now in place ([ADR 0004](0004-supabase-migrations-as-source.md)): table/column DDL is generated from `schema.prisma` via `yarn db:new`, and the Postgres functions are hand-written SQL appended to the same migration (Prisma cannot express them). This is consistent with the stated target architecture principle — *Drizzle for 90% CRUD, Postgres functions for concurrency-critical operations.* Because `supabase/migrations/*.sql` is the source of truth, the functions are stack-agnostic SQL and survive the later Drizzle migration untouched.
 
 Assigned seating (per-unit inventory rows + `FOR UPDATE SKIP LOCKED`) is explicitly **not** built — events are general-admission only for the foreseeable future.
 

--- a/docs/plans/2026-06-checkout-reservation-rebuild.md
+++ b/docs/plans/2026-06-checkout-reservation-rebuild.md
@@ -1,0 +1,120 @@
+---
+title: Checkout / Inventory / Payment — Reservation-Based Rebuild
+status: proposed
+created: 2026-06-02
+tracking-issue: TBD
+---
+
+# Checkout / Inventory / Payment — Reservation-Based Rebuild
+
+Spec and phased plan for replacing the inventory accounting model with a reservation-based design. Realizes roadmap **P4.3** (reservation checkout) and the **P2** schema corrections the checkout depends on, executed now on the current Prisma + Postgres stack. Backing decision: [ADR 0004](../adr/0004-reservation-based-checkout.md). Roadmap context: [`roadmap.md`](../roadmap.md) Priority 1 (bugs 1.1–1.3), Priority 2, Priority 4.3.
+
+## Context
+
+TropTix is **live and serving real events**. The three Priority-1 bugs — overselling race (1.1), non-atomic payment confirmation (1.2), Stripe version drift (1.3) — are symptoms of **one root cause: the inventory accounting model.**
+
+Verified current state:
+- A mutable `quantitySold` counter is incremented in two places (free path inline in `apps/web/src/app/api/checkout/initiate/route.ts:328`, paid path in `apps/web/src/pages/api/stripe/webhook.ts:146`) and **never decremented on expiry**.
+- "Availability" is computed live as `quantity − completedTickets − pendingTickets` by counting `Tickets` rows (`validateTicketType`, `initiate/route.ts:411`), while the organizer dashboard reads the *counter* (`getEventOverview.ts`) — **two disagreeing sources of truth**.
+- A **PENDING `Orders` row is the implicit reservation**, so every availability read joins orders+tickets and special-cases PENDING.
+- The 5-minute expiry cron (`apps/web/src/app/api/cron/invalidate-orders/route.ts`) cancels orders but **releases no inventory**.
+
+Rather than three patches (a `FOR UPDATE` lock thrown away once reservations land, a webhook transaction, a shared client), we replace the model once. This is the forward-compatible foundation for the planned Drizzle/Supabase migration.
+
+**Decisions (confirmed):** scope = checkout subsystem + the schema corrections it depends on (cosmetic renames deferred); sequencing = rebuild in place on Prisma+Postgres, not strangler; inventory = general-admission counter model.
+
+---
+
+## Target Design
+
+### 1. Inventory: counter columns + atomic conditional decrement
+
+Replace `quantitySold` with `capacity` (immutable total, rename of `quantity`), `reserved` (held by active reservations), `sold` (confirmed). **availability = `capacity − reserved − sold`**, read directly. Reserve is a single atomic statement inside a Postgres function:
+```sql
+UPDATE "TicketTypes"
+SET reserved = reserved + :qty
+WHERE id = :id AND (capacity - reserved - sold) >= :qty;  -- 0 rows => insufficient stock
+```
+Correct at READ COMMITTED — **structurally eliminates bug 1.1**, no lock or retry loop. The function clamps to available per type and returns granted quantities, preserving the "wasAdjusted" UX.
+
+### 2. Explicit reservation, not a PENDING order
+
+```
+Reservation { id, eventId, status (HELD|CONVERTED|EXPIRED|RELEASED),
+              expiresAt, stripePaymentIntentId? @unique, orderId?,
+              email, firstName, lastName, userId?, createdAt, updatedAt }
+ReservationItem { id, reservationId, ticketTypeId, quantity, unitPriceCents, feesCents }
+```
+`Order` + `OrderTicket` are materialized only on payment success. Availability reads never touch orders again.
+
+### 3. Payment confirmation: single source of truth, atomic + idempotent
+
+`confirm_reservation()` in one transaction: find HELD reservation by payment-intent id (**already CONVERTED → no-op**, the idempotency guard for Stripe's at-least-once delivery); `reserved -= q; sold += q` per item; create `Order` + `OrderTicket`s (status VALID); mark reservation CONVERTED; insert an outbox row for the confirmation email (sent after commit / by cron drain — never inside the txn). **Eliminates bug 1.2** and the double-increment hazard.
+
+### 4. Expiry releases inventory
+
+`expire_reservations(now)` (called by the repurposed cron): for each HELD reservation past `expiresAt`, `reserved -= q` per item, mark EXPIRED. Idempotent; lazy release on read supported.
+
+### 5. Stripe client
+
+New `apps/web/src/server/lib/stripe.ts`: one shared client, `apiVersion: '2023-10-16'` (matches installed `stripe@14.25.0` `LatestApiVersion` — drops every `@ts-ignore`). Idempotency key = reservation id on `paymentIntents.create`. **Eliminates bug 1.3.** Leave the ephemeral-key `2020-08-27` (`pages/api/stripe/index.ts:99`) independent — it must match the mobile Stripe SDK.
+
+### 6. Postgres functions (concurrency-critical core)
+
+Authored as raw SQL in Prisma migrations, called via `$queryRaw`/`$executeRaw`: `reserve_tickets`, `confirm_reservation`, `release_reservation`, `expire_reservations`.
+
+### 7. Schema corrections the checkout depends on
+
+| Change | Why required here |
+|---|---|
+| Money → integer **cents** | Exact Stripe amounts + inventory math; removes `Math.round`/`toFixed` hacks. |
+| `startsAt`/`endsAt`, `saleStartsAt`/`saleEndsAt` | Reservation checks the sale window; split date/time today **ignores the time** (`initiate/route.ts:394`) — a real bug. |
+| Ticket statuses → `VALID`/`USED`/`CANCELLED`/`REFUNDED` + `checkinTimestamp` | `AVAILABLE`/`NOT_AVAILABLE` is overloaded (unpaid vs scanned); scan/check-in toggles the same flag. |
+| Order-level `type` (FREE/PAID/COMPLEMENTARY) | One reservation→confirm path for all order kinds. |
+| `Orders.createdAt` non-nullable | Expiry depends on it. |
+
+**Deferred** (companion rename sweep, no behavior change): table/field renames, dropping dead tables, `discountCode`→`password`, `organizer`→`hostName`, dropping redundant `name`.
+
+---
+
+## Files & Consumers
+
+**New:** `apps/web/src/server/lib/stripe.ts`; `apps/web/src/server/lib/reservations.ts` (TS wrappers over the SQL functions); Prisma migrations (additive, then cleanup) carrying the functions.
+
+**Checkout path:**
+- `app/api/checkout/initiate/route.ts` → "create reservation": call `reserve_tickets`, create PaymentIntent (idempotency key = reservation id), return `clientSecret` + `reservationId` + granted quantities. Delete PENDING-order creation, `validateTicketType` stock math, `getPrismaCreateOrderPayload`. Free orders run reservation→`confirm_reservation` immediately.
+- `app/api/checkout/config/route.ts`, `app/api/checkout/apply-code/route.ts` → availability = `capacity − reserved − sold` (drop order-counting).
+- `pages/api/stripe/webhook.ts` → call `confirm_reservation`; email from outbox after commit. (Stays in Pages Router; App-Router move is P3.2.) Retire the `orderHelper` increment helpers.
+- `app/api/cron/invalidate-orders/route.ts` → call `expire_reservations`; optionally drain the outbox.
+
+**Organizer reads:**
+- `getEventOverview.ts` + tickets page → read `sold` (+ optionally `reserved`); revenue from completed Orders.
+- `app/api/organizer/tickets/scan/route.ts`, `check-in/route.ts` → set `USED` + `checkinTimestamp`.
+- Complementary tickets (`orderHelper.ts:113`) → reservation of `type=COMPLEMENTARY` incrementing `sold`.
+
+**Client (mostly unchanged):** `CheckoutContainer.tsx` / `payment-form.tsx` keep Stripe Elements `confirmPayment`; hold `reservationId` until confirmation; confirmation page resolves the order from the converted reservation.
+
+---
+
+## Phases (one PR each)
+
+- **Phase A — Foundation (no behavior change).** Additive migration: new columns (`capacity`/`reserved`/`sold`, `*Cents`, `startsAt`/`endsAt`/`saleStartsAt`/`saleEndsAt`, order `type`, `checkinTimestamp`, new status enum values), new tables (`Reservation`, `ReservationItem`, `OutboxMessage`, optional `ProcessedStripeEvent`), and the Postgres functions. Backfill: `sold = quantitySold`; `capacity = quantity`; `*Cents = round(price*100)`; `startsAt = startDate (+ startTime)`; status mapping. Old columns retained. Add shared Stripe client + stand up the jest harness.
+- **Phase B — Cut over checkout.** Switch initiate/config/apply-code/webhook/cron to the reservation model. **`reserved` seeded from in-flight PENDING holds at cutover** (the one genuine risk) — deploy in a low-traffic window with a brief checkout pause during seed+switch. Full test suite here.
+- **Phase C — Organizer reads.** Dashboard, scan/check-in, complementary path move to new columns/statuses.
+- **Phase D — Cleanup.** Drop `quantitySold`/`quantity`/`price`/`startDate`/`startTime`/old statuses; remove dead code. Optional deferred rename sweep.
+
+---
+
+## Verification
+
+- **Concurrency (headline):** integration test against a **real Postgres** — N concurrent `reserve_tickets` for `capacity = 1`; assert exactly one grant, `reserved` never exceeds `capacity`.
+- **Idempotency:** `confirm_reservation` twice for one payment intent → `sold` increments once, one Order.
+- **Expiry:** HELD reservation past `expiresAt` → `reserved` released, status EXPIRED.
+- **Money:** cents round-trips with Stripe amounts (no float drift).
+- **Sale window:** ticket with `saleStartsAt` later today is unavailable now.
+- **E2E manual:** Stripe CLI `stripe listen --forward-to localhost:<port>/api/stripe/webhook` + `stripe trigger payment_intent.succeeded`; confirm reservation→order, one email, `sold` incremented; replay to confirm no double-count; two simultaneous `curl` checkouts on `capacity:1` → exactly one order.
+- **Per PR:** `cd apps/web && npm run typecheck && npm test`.
+
+## Out of scope
+
+Drizzle (P4.1), Supabase Auth (P4.2), webhook → App Router (P3.2), full transactional email service (P4.4 — minimal outbox only), Stripe Connect, cosmetic renames. The design is forward-compatible with each.

--- a/docs/plans/2026-06-checkout-reservation-rebuild.md
+++ b/docs/plans/2026-06-checkout-reservation-rebuild.md
@@ -7,7 +7,7 @@ tracking-issue: TBD
 
 # Checkout / Inventory / Payment — Reservation-Based Rebuild
 
-Spec and phased plan for replacing the inventory accounting model with a reservation-based design. Realizes roadmap **P4.3** (reservation checkout) and the **P2** schema corrections the checkout depends on, executed now on the current Prisma + Postgres stack. Backing decision: [ADR 0004](../adr/0004-reservation-based-checkout.md). Roadmap context: [`roadmap.md`](../roadmap.md) Priority 1 (bugs 1.1–1.3), Priority 2, Priority 4.3.
+Spec and phased plan for replacing the inventory accounting model with a reservation-based design. Realizes roadmap **P4.3** (reservation checkout) and the **P2** schema corrections the checkout depends on, executed now on the current Prisma + Postgres stack. Backing decision: [ADR 0007](../adr/0007-reservation-based-checkout.md). Schema/function changes ship through the Supabase migrations pipeline ([ADR 0004](../adr/0004-supabase-migrations-as-source.md), [migrations-adoption plan](2026-06-migrations-adoption.md)). Roadmap context: [`roadmap.md`](../roadmap.md) Priority 1 (bugs 1.1–1.3), Priority 2, Priority 4.3.
 
 ## Context
 
@@ -61,7 +61,7 @@ New `apps/web/src/server/lib/stripe.ts`: one shared client, `apiVersion: '2023-1
 
 ### 6. Postgres functions (concurrency-critical core)
 
-Authored as raw SQL in Prisma migrations, called via `$queryRaw`/`$executeRaw`: `reserve_tickets`, `confirm_reservation`, `release_reservation`, `expire_reservations`.
+Authored as hand-written SQL inside a Supabase migration (`supabase/migrations/<ts>_*.sql`), appended after the `db:new`-generated DDL since Prisma cannot express functions. Called from app code via `$queryRaw`/`$executeRaw`: `reserve_tickets`, `confirm_reservation`, `release_reservation`, `expire_reservations`.
 
 ### 7. Schema corrections the checkout depends on
 
@@ -79,7 +79,7 @@ Authored as raw SQL in Prisma migrations, called via `$queryRaw`/`$executeRaw`: 
 
 ## Files & Consumers
 
-**New:** `apps/web/src/server/lib/stripe.ts`; `apps/web/src/server/lib/reservations.ts` (TS wrappers over the SQL functions); Prisma migrations (additive, then cleanup) carrying the functions.
+**New:** `apps/web/src/server/lib/stripe.ts` (shipped in PR #279); `apps/web/src/server/lib/reservations.ts` (TS wrappers over the SQL functions); Supabase migrations under `supabase/migrations/` (additive, then cleanup) carrying the DDL + functions + backfill.
 
 **Checkout path:**
 - `app/api/checkout/initiate/route.ts` → "create reservation": call `reserve_tickets`, create PaymentIntent (idempotency key = reservation id), return `clientSecret` + `reservationId` + granted quantities. Delete PENDING-order creation, `validateTicketType` stock math, `getPrismaCreateOrderPayload`. Free orders run reservation→`confirm_reservation` immediately.
@@ -98,7 +98,8 @@ Authored as raw SQL in Prisma migrations, called via `$queryRaw`/`$executeRaw`: 
 
 ## Phases (one PR each)
 
-- **Phase A — Foundation (no behavior change).** Additive migration: new columns (`capacity`/`reserved`/`sold`, `*Cents`, `startsAt`/`endsAt`/`saleStartsAt`/`saleEndsAt`, order `type`, `checkinTimestamp`, new status enum values), new tables (`Reservation`, `ReservationItem`, `OutboxMessage`, optional `ProcessedStripeEvent`), and the Postgres functions. Backfill: `sold = quantitySold`; `capacity = quantity`; `*Cents = round(price*100)`; `startsAt = startDate (+ startTime)`; status mapping. Old columns retained. Add shared Stripe client + stand up the jest harness.
+- **PR 1 — Shared Stripe client (shipped, PR #279).** One `server/lib/stripe.ts` pinned to `2023-10-16`, replacing three ad-hoc clients; root fix for bug 1.3.
+- **Phase A — Schema + functions foundation (no behavior change).** Authored through the Supabase migrations pipeline against a per-PR **preview branch** (no local DB): edit `schema.prisma` → `yarn db:new checkout_reservation_foundation` generates the table/column DDL → **hand-append** to the migration the RLS-enable for the new tables, the data backfill, and the `CREATE FUNCTION` statements → `yarn db:apply` to the branch → verify the branch replays cleanly. Adds columns (`capacity`/`reserved`/`sold`, `*Cents`, `startsAt`/`endsAt`/`saleStartsAt`/`saleEndsAt`, order `type`, `checkinTimestamp`, new status enum values), new tables (`Reservation`, `ReservationItem`, `OutboxMessage`, optional `ProcessedStripeEvent` — all with RLS enabled per the #281 convention), and the Postgres functions. Backfill: `sold = quantitySold`; `capacity = quantity`; `*Cents = round(price*100)`; `startsAt = startDate (+ startTime)`; status mapping. Old columns retained (additive ⇒ all new columns nullable or defaulted). Also stand up the jest harness (jest is referenced in `package.json` but not installed).
 - **Phase B — Cut over checkout.** Switch initiate/config/apply-code/webhook/cron to the reservation model. **`reserved` seeded from in-flight PENDING holds at cutover** (the one genuine risk) — deploy in a low-traffic window with a brief checkout pause during seed+switch. Full test suite here.
 - **Phase C — Organizer reads.** Dashboard, scan/check-in, complementary path move to new columns/statuses.
 - **Phase D — Cleanup.** Drop `quantitySold`/`quantity`/`price`/`startDate`/`startTime`/old statuses; remove dead code. Optional deferred rename sweep.
@@ -107,7 +108,7 @@ Authored as raw SQL in Prisma migrations, called via `$queryRaw`/`$executeRaw`: 
 
 ## Verification
 
-- **Concurrency (headline):** integration test against a **real Postgres** — N concurrent `reserve_tickets` for `capacity = 1`; assert exactly one grant, `reserved` never exceeds `capacity`.
+- **Concurrency (headline):** integration test against the PR's **Supabase preview branch** (a real Postgres) — N concurrent `reserve_tickets` for `capacity = 1`; assert exactly one grant, `reserved` never exceeds `capacity`.
 - **Idempotency:** `confirm_reservation` twice for one payment intent → `sold` increments once, one Order.
 - **Expiry:** HELD reservation past `expiresAt` → `reserved` released, status EXPIRED.
 - **Money:** cents round-trips with Stripe amounts (no float drift).


### PR DESCRIPTION
First PR in the **reservation-based checkout / inventory / payment rebuild**.

📄 Plan: [`docs/plans/2026-06-checkout-reservation-rebuild.md`](https://github.com/TropTix/troptix/blob/checkout-rebuild/01-shared-stripe-client/docs/plans/2026-06-checkout-reservation-rebuild.md) · Decision: [ADR 0004](https://github.com/TropTix/troptix/blob/checkout-rebuild/01-shared-stripe-client/docs/adr/0004-reservation-based-checkout.md)

## Why this rebuild
The three Priority-1 bugs share **one root cause — the inventory accounting model** (a mutable `quantitySold` counter incremented in two places and never released on expiry; a PENDING order used as an implicit reservation; availability counted from order rows in one place and read from the counter in another). Rather than three throwaway patches, we replace the model once with a reservation pattern, which eliminates all three structurally and is forward-compatible with the planned Drizzle/Supabase migration.

## What this PR does (root fix for bug 1.3)
- Adds `apps/web/src/server/lib/stripe.ts` — one shared Stripe client.
- Replaces three ad-hoc `new Stripe(...)` instantiations (versions `2024-04-10`, `2023-08-16`, `2020-08-27`, all behind `@ts-ignore`) with that client, pinned to **`2023-10-16`** = the `LatestApiVersion` of the installed `stripe@14.25.0`, so the type matches and **every `@ts-ignore` is removed**.
- Keeps the mobile ephemeral-key version as `MOBILE_STRIPE_API_VERSION` (`2020-08-27`) — it must track the **mobile** Stripe SDK, not the server, so it is deliberately *not* unified.
- Ships the plan doc + ADR 0004.

**Behavior note:** this aligns the checkout and webhook paths onto a single API version (`2023-10-16`). The fields used (`payment_method`, `card.brand`/`last4`, `client_secret`, payment-intent create) are stable across `2023-08-16`→`2023-10-16`→`2024-04-10`, so the change is low-risk; pinning to the SDK's bundled version is the correct, type-safe baseline.

**Verification:** `npm run typecheck` passes with all `@ts-ignore`s gone. Pure refactor — no DB or schema changes.

---

## Follow-up PRs (this is 1 of 6)
The rebuild is phased so each PR is independently reviewable; the risky schema/SQL is isolated from the verified refactors.

- **2/6 — Schema foundation + Postgres functions (additive, no behavior change).** Add `Reservation`/`ReservationItem`/`OutboxMessage` tables; add `capacity`/`reserved`/`sold`, integer-cents columns, `startsAt`/`endsAt`/`saleStartsAt`/`saleEndsAt`, order-level `type`, `checkinTimestamp`, and new ticket-status enum values; author the `reserve_tickets` / `confirm_reservation` / `release_reservation` / `expire_reservations` Postgres functions as raw SQL (this repo uses `db push` + a SQL-functions apply step, no migration history yet). Backfill old → new columns. Stand up the jest harness (jest is referenced but not installed).
- **3/6 — Checkout cutover (fixes 1.1 + 1.2).** `initiate` becomes *create-reservation* (atomic conditional decrement → no oversell; idempotency key = reservation id); `config`/`apply-code` read `capacity − reserved − sold`; the webhook calls the atomic, idempotent `confirm_reservation`; the cron calls `expire_reservations` to release held inventory. **Seeds `reserved` from in-flight PENDINGs in a low-traffic window** — the one genuine cutover risk. Concurrency + idempotency + expiry tests against a real Postgres.
- **4/6 — Organizer reads.** Dashboard + tickets page read `sold`/`reserved`; scan/check-in set `USED` + `checkinTimestamp`; complementary tickets issue via a `COMPLEMENTARY` reservation.
- **5/6 — Cleanup.** Drop `quantitySold`/`quantity`/`price`/`startDate`/`startTime`/old statuses; remove dead code (`getPrismaCreateOrderPayload`, the increment helpers).
- **6/6 (optional) — Cosmetic rename sweep.** Table/field renames, drop dead tables, `discountCode`→`password`, `organizer`→`hostName`.

**Out of scope:** Drizzle (P4.1), Supabase Auth (P4.2), webhook → App Router (P3.2), full email service (P4.4 — minimal outbox only), Stripe Connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)