### PR TITLE
Database migrations pipeline + prod baseline (Phase 0–1)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "postinstall": "prisma generate",
+    "db:new": "tsx scripts/new-migration.ts",
+    "db:apply": "supabase db push --db-url \"$DEV_DIRECT_URL\"",
     "knip": "knip"
   },
   "engines": {

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1,6 +1,7 @@
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL") // pooled (6543) — used by the app at runtime
+  directUrl = env("DIRECT_URL")   // direct (5432) — required for migrations / diff
   // relationMode = "prisma"
 }
 

--- a/apps/web/scripts/new-migration.ts
+++ b/apps/web/scripts/new-migration.ts
@@ -1,0 +1,75 @@
+/**
+ * Generate a Supabase-format migration from the current Prisma schema.
+ *
+ * Usage:
+ *   yarn db:new <name>          # diff: dev DB  -> schema.prisma
+ *   yarn db:new <name> --init   # diff: empty   -> schema.prisma  (baseline, Phase 0)
+ *
+ * Writes supabase/migrations/<timestamp>_<name>.sql using `prisma migrate diff`.
+ * Plain SQL is the source of truth (docs/adr/0004-supabase-migrations-as-source.md);
+ * Prisma is only the generator. Review the emitted SQL before committing.
+ *
+ * Env:
+ *   DEV_DIRECT_URL  direct (5432) connection to the dev DB, used as the diff baseline.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const rawName = process.argv[2];
+const isInit = process.argv.includes("--init");
+
+if (!rawName || rawName.startsWith("--")) {
+  console.error("Usage: yarn db:new <name> [--init]");
+  process.exit(1);
+}
+
+const name = rawName.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
+
+// Supabase migration filename convention: <YYYYMMDDHHMMSS>_<name>.sql
+const d = new Date();
+const pad = (n: number) => String(n).padStart(2, "0");
+const timestamp =
+  `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}` +
+  `${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}`;
+
+const webDir = join(__dirname, "..");
+const schemaPath = join(webDir, "prisma", "schema.prisma");
+const migrationsDir = join(webDir, "..", "..", "supabase", "migrations");
+const outFile = join(migrationsDir, `${timestamp}_${name}.sql`);
+
+const fromArgs = isInit
+  ? ["--from-empty"]
+  : (() => {
+      const url = process.env.DEV_DIRECT_URL;
+      if (!url) {
+        console.error("DEV_DIRECT_URL is required (direct 5432 connection to the dev DB).");
+        console.error("Use --init for the first baseline migration (diff from empty).");
+        process.exit(1);
+      }
+      return ["--from-url", url];
+    })();
+
+const sql = execFileSync(
+  "npx",
+  [
+    "prisma",
+    "migrate",
+    "diff",
+    ...fromArgs,
+    "--to-schema-datamodel",
+    schemaPath,
+    "--script",
+  ],
+  { cwd: webDir, encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] },
+);
+
+if (!sql.trim() || /^\s*--\s*This is an empty migration\.?\s*$/im.test(sql.trim())) {
+  console.log("No schema changes detected — nothing to write.");
+  process.exit(0);
+}
+
+mkdirSync(migrationsDir, { recursive: true });
+writeFileSync(outFile, sql);
+console.log(`Wrote ${outFile}`);
+console.log("Review the SQL, then run `yarn db:apply` to apply it to your dev/local DB.");

--- a/docs/adr/0004-supabase-migrations-as-source.md
+++ b/docs/adr/0004-supabase-migrations-as-source.md
@@ -1,0 +1,23 @@
+# 4. Supabase migrations as the schema source of truth
+
+- **Status:** Proposed
+- **Date:** 2026-06-02
+
+## Context
+
+`apps/web` syncs its schema with `prisma db push` (no migration history). We want: reviewable migrations, automatic prod apply on merge, and an isolated database per PR that is created on open and destroyed on close. Two constraints dominate:
+
+- Prisma migrations are forward-only — "revert on PR close" can only mean *destroy an ephemeral DB*, which requires database branching (one DB per PR), not a shared dev DB.
+- The roadmap plans a Prisma → Drizzle migration, so the pipeline must not be Prisma-specific.
+
+Supabase Branching (native GitHub integration) creates/migrates/destroys a preview database per PR and auto-wires the Vercel preview — but it runs SQL from `supabase/migrations`, not `prisma/migrations`.
+
+## Decision
+
+Make **`supabase/migrations/*.sql` the source of truth** for schema changes. Prisma is used only to *author* and *generate* that SQL (`prisma migrate diff`); **Supabase Branching** owns the full lifecycle — per-PR ephemeral databases *and* applying migrations to production on merge to `main`. No GitHub Actions / CI step for prod apply: Branching already does it, so a parallel `db push` would only duplicate the path and add CI secrets to manage. Do **not** upgrade Prisma (stays `5.x`) — it is a soon-to-be-replaced SQL generator.
+
+## Consequences
+
+- **Good:** True per-PR isolation with safe teardown. ORM-agnostic SQL store survives the Drizzle move untouched — only the authoring step changes later. One prod-apply authority (Supabase Branching) — no CI workflow or secrets to maintain. No wasted Prisma major-upgrade work.
+- **Trade-off:** Two representations of schema during the Prisma era (`schema.prisma` for authoring, `supabase/migrations` for truth) kept in sync by a generate step. Generated diffs depend on the dev DB not drifting from history (mitigated by treating dev as derived-from-migrations).
+- **Bad:** Couples the **whole** pipeline — dev/PR *and* prod apply — to Supabase Branching (a paid, Supabase-specific feature) and the Supabase↔Vercel integration. No independent CI fallback for prod migrations; if Branching is down or disabled, prod applies must be run manually (`supabase db push --linked`).

--- a/docs/adr/0005-local-only-dev-no-persistent-dev-db.md
+++ b/docs/adr/0005-local-only-dev-no-persistent-dev-db.md
@@ -1,0 +1,23 @@
+# 5. Local-only development, no persistent dev database
+
+- **Status:** Superseded by [6](0006-hosted-branching-persistent-dev-branch.md)
+- **Date:** 2026-06-03
+
+## Context
+
+The migrations pipeline ([ADR 0004](0004-supabase-migrations-as-source.md)) introduced two ways to get a database without a shared dev DB: the **local stack** (`supabase start`, Docker — rebuilt from `supabase/migrations` + `seed.sql`) and **per-PR preview branches** (Supabase Branching). That left the long-lived hosted **dev DB** doing only one job: giving app-only work real, prod-like data with zero boot time.
+
+The original plan recommended keeping the dev DB for that reason. But it is an always-on database billing continuously, and as a solo project the things a shared hosted dev DB buys (a URL other people/tools can hit, collision-free concurrent access) don't apply. Two facts make local-only viable:
+
+- The local stack's data **persists across `db:stop`/`db:start`** (Docker volume) — it is not wiped each session; only `db:reset` rebuilds it. So a local DB can hold a durable working dataset.
+- Real data can be loaded **once** via `pg_dump`/`pg_restore` into the local stack and then persists.
+
+## Decision
+
+Retire the persistent hosted dev DB. Development is **local-only** (the `supabase start` stack) plus **per-PR preview branches** from Supabase Branching. No always-on dev database. Real-volume data for local dev comes from a maintained `seed.sql` and an optional one-time `pg_dump` restore into the local stack.
+
+## Consequences
+
+- **Good:** Removes the recurring cost of an always-on dev DB. The local stack is also the correct migration-authoring environment (always at migration head via `db:reset`), so there's one fewer environment to keep in sync. Per-PR isolation is unchanged (preview branches).
+- **Trade-off:** No real prod-volume data by default — mitigated by `seed.sql` and the optional dump-and-restore (data persists in the Docker volume). Local dev now requires Docker running and a ~20–30s `db:start`.
+- **Bad:** No always-on hosted dev URL for sharing or remote/automated access. If that need arises later, a persistent Supabase branch can be stood up without reversing this decision.

--- a/docs/adr/0006-hosted-branching-persistent-dev-branch.md
+++ b/docs/adr/0006-hosted-branching-persistent-dev-branch.md
@@ -1,0 +1,29 @@
+# 6. Hosted Supabase Branching for all dev environments; persistent dev branch, no local Docker
+
+- **Status:** Accepted
+- **Date:** 2026-06-04
+- **Supersedes:** [5](0005-local-only-dev-no-persistent-dev-db.md)
+
+## Context
+
+[ADR 0005](0005-local-only-dev-no-persistent-dev-db.md) made development local-only (the `supabase start` Docker stack) plus per-PR preview branches. In practice that puts a hard dependency on every contributor running and managing Docker — a boot step, disk, and a class of "is the daemon up?" friction — just to run the frontend. For a project where most work is app/frontend changes that never touch the schema, that cost is paid constantly for a benefit (isolated migration replay) that only matters occasionally.
+
+We want the common path — frontend iteration — to require **nothing installed**, while still getting true per-PR isolation when a change touches the schema.
+
+## Decision
+
+All database environments are **hosted via Supabase Branching**; there is **no local Docker stack**.
+
+- **Persistent dev branch** (always-on, tracks `main`): the default target for app/frontend work. Schema stays current — migrations apply on merge. Its **data is loaded once** via a `pg_dump`/`pg_restore` from the (retiring) dev DB — real data that lives in the branch's database, never in git. Production data is never cloned in (`--with-data` is not used).
+- **Ephemeral preview branch** (per PR): spun up for schema changes, used to author and validate the migration in isolation, destroyed on PR close. Seeded from `supabase/seed.sql` — a **small synthetic fixture** (one demo organizer/event/ticket types), not real data. The Supabase↔Vercel integration auto-wires the PR's preview deploy to it.
+- **Prod**: fed by Branching on merge to `main`.
+
+Real data is therefore confined to the one long-lived, access-controlled dev branch; nothing real is committed to git (`seed.sql` stays synthetic) or copied into per-PR preview branches.
+
+Consequences of removing the local stack: the **migration-authoring diff baseline** moves from local `54322` to a preview branch held at migration head (kept current with `yarn db:apply`), and the **"replays from empty" validation** moves from `db:reset` to preview-branch creation (which builds from `supabase/migrations` + `seed.sql`). The local-stack scripts (`db:start/stop/status/reset`, `scripts/db-start.sh`) are removed.
+
+## Consequences
+
+- **Good:** Zero local setup for the common case — contributors run the app against the always-on dev branch with nothing to install. One obvious path. Migration replay and per-PR isolation now validate on the real target (a Supabase branch) rather than a local approximation. Nothing real is committed to git, and no data is cloned into per-PR preview branches.
+- **Trade-off:** The dev branch is realistic (one-time dev-data load), but **preview-branch** realism is bounded by the synthetic `seed.sql`. The dev branch holds real data, so it must be access-controlled like any environment with real records. Authoring a migration now requires a live preview branch and keeping it at head (`db:apply` after each migration) instead of a local `db:reset`.
+- **Bad:** Cost and hosted-dependency increase — the persistent dev branch is an always-on billed instance, every preview branch is billed while open, and all dev/PR work now hard-depends on Supabase Branching availability (no offline option, since the local stack is gone).

--- a/docs/plans/2026-06-migrations-adoption.md
+++ b/docs/plans/2026-06-migrations-adoption.md
@@ -1,0 +1,177 @@
+---
+title: Database Migrations Adoption
+status: proposed
+created: 2026-06-02
+tracking-issue: TBD
+---
+
+# Database Migrations Adoption
+
+Move `apps/web` off ad-hoc `prisma db push` onto a reviewable, replayable migration pipeline with per-PR isolated databases and automated production deploys. Decision rationale captured in [ADR 0004](../adr/0004-supabase-migrations-as-source.md).
+
+## Context
+
+Today the schema in [`apps/web/prisma/schema.prisma`](../../apps/web/prisma/schema.prisma) is synced with `prisma db push` — there is no `prisma/migrations/` history. Infra:
+
+- **Dev DB** (Supabase, standalone project): local dev + (currently) Vercel PR previews point here. **Being retired** — superseded by a **persistent Supabase dev branch** + per-PR preview branches, no local Docker ([ADR 0006](../adr/0006-hosted-branching-persistent-dev-branch.md), superseding [ADR 0005](../adr/0005-local-only-dev-no-persistent-dev-db.md)).
+- **Prod DB** (Supabase): production app.
+- No CI (`.github/workflows` is empty). No `vercel.json` (Vercel configured via dashboard).
+- Prisma `^5.14.0`.
+
+Goals:
+1. Apply migrations to **prod automatically on merge to `main`**.
+2. Give each **PR an isolated database**: migrations applied when the PR opens, the database **destroyed when the PR closes** (true "revert on close").
+3. Keep authoring schema in Prisma for now.
+
+Hard constraints that shaped the design:
+- **Prisma migrations are forward-only** — there is no down/rollback. "Revert" can only mean *destroy an ephemeral database*, not undo a migration.
+- A **single shared dev DB cannot** safely support apply-on-open/revert-on-close: concurrent PRs would corrupt each other's schema. Isolation is mandatory → database branching.
+- The longer-term plan is **Prisma → Drizzle** (see [architecture roadmap](../roadmap.md)). The migration pipeline must not be welded to Prisma.
+
+## Decision
+
+Source of truth for schema changes becomes **`supabase/migrations/*.sql`** — plain, ORM-agnostic SQL. See [ADR 0004](../adr/0004-supabase-migrations-as-source.md).
+
+| Concern | Mechanism | Trigger |
+|---|---|---|
+| Migration store | `supabase/migrations/<timestamp>_<name>.sql` (committed) | git |
+| Authoring | edit `schema.prisma` → `prisma migrate diff` emits SQL, diffed against a **preview branch** at migration head | `yarn db:new <name>` |
+| Default dev environment (app/frontend work) | **persistent Supabase dev branch** (tracks `main`, schema current on merge; **data loaded once** from the retiring dev DB, lives in the branch not git) | always-on |
+| Per-PR ephemeral DB (apply on open / **destroy on close**) | **Supabase Branching** (native GitHub integration) | PR opened / closed |
+| Preview app → branch DB | Supabase↔Vercel integration auto-injects `DATABASE_URL`/`DIRECT_URL` into the preview | per preview deploy |
+| **Prod apply on merge** | **Supabase Branching** auto-applies `supabase/migrations` to the production database when the PR merges to `main` | merge to `main` |
+
+Why not the alternatives:
+- **Upgrade Prisma first?** No. Under this design Prisma is only a SQL generator on the way to Drizzle; a 5→7 major upgrade (ESM client, required generator `output`, Node baseline, config breakage) is throwaway churn. Stay on 5.x.
+- **Shared dev DB, forward-only?** Rejected — can't give per-PR isolation/revert (the stated requirement).
+- **Prisma migrations as the store?** Rejected — Supabase Branching reads `supabase/migrations`, and a plain-SQL store survives the Drizzle migration unchanged.
+- **GitHub Actions for prod apply?** Rejected — Supabase Branching already applies migrations to production on merge to `main`. A parallel GHA `db push` duplicates that path and means a second set of CI secrets to manage. Let Branching own prod end-to-end; keep one documented authority.
+
+## Phases
+
+### Phase 0 — Baseline the existing databases (prerequisite)
+The prod/dev DBs already have the full schema but no migration history. A fresh **preview** branch, by contrast, builds from an empty DB and runs *every* file in `supabase/migrations`. So the first migration must reconstruct the entire current schema from empty, and the existing persistent DBs must be told they're already at that baseline.
+
+1. Generate the baseline from the current schema:
+   ```bash
+   cd apps/web
+   yarn db:new init --init        # emits supabase/migrations/<ts>_init.sql via prisma migrate diff --from-empty
+   ```
+   Review the SQL — it should be the full `CREATE TABLE …` set matching prod.
+2. Verify no drift between the SQL and the live DBs:
+   ```bash
+   npx prisma migrate diff --from-url "$DEV_DIRECT_URL" \
+     --to-schema-datamodel prisma/schema.prisma --script   # expect empty
+   ```
+3. Mark prod and dev as already at the baseline so `db push` won't try to re-create:
+   ```bash
+   supabase migration repair --status applied <ts> --linked   # against each persistent project
+   ```
+4. Capture a representative `supabase/seed.sql` (no production PII) for preview branches.
+
+### Phase 1 — Wire the pipeline (this plan's PRs)
+- Add `supabase/` (`config.toml`, `migrations/`, `seed.sql`).
+- Add `apps/web/scripts/new-migration.ts` + `db:new` / `db:apply` package scripts.
+- Add `directUrl` to the datasource block in `schema.prisma`.
+
+### Phase 2 — Enable Supabase Branching + integrations (one-time, dashboard)
+See the checklist at the bottom — these are console steps that can't be committed. Branching owns per-PR preview DBs, the **persistent dev branch**, **and** the prod apply on merge, so there is no CI workflow or GitHub secrets to configure. Includes creating the persistent dev branch (seed-only) and retiring the old standalone dev DB.
+
+### Phase 3 — Cut over
+- Stop all use of `prisma db push`.
+- First real schema change goes through `yarn db:new` → PR → preview branch verifies → merge → **Supabase Branching applies to prod**.
+
+## Environments — which DB to use when
+
+**Everything is hosted via Supabase Branching — no local Docker stack.** See [ADR 0006](../adr/0006-hosted-branching-persistent-dev-branch.md). Pick by the *kind* of change.
+
+| Environment | What it is | Use it for |
+|---|---|---|
+| **Persistent dev branch** (Supabase) | Always-on branch tracking `main`; schema stays current (migrations apply on merge); **real data loaded once** from the dev DB (one-time `pg_dump` restore, lives in the branch, not git) | **App / frontend work that doesn't touch the schema** — fast iteration on real-ish data, nothing to install |
+| **Preview branch** (ephemeral, per PR) | Created on PR open from `supabase/migrations` + the synthetic `seed.sql` fixture, **destroyed on close** | **Schema changes** — author + validate the migration in isolation |
+| **Prod** | Production database | Not used directly — fed by Branching on merge |
+
+Decision rule:
+- **Not touching the schema?** Point the app at the **persistent dev branch**. No Docker, real-ish (seed) data, always up.
+- **Touching the schema?** Open a PR (or `supabase branches create`) → a **preview branch** spins up. Point `DATABASE_URL`/`DIRECT_URL`/`DEV_DIRECT_URL` at that branch; the Vercel preview is wired to it automatically.
+
+**Diff baseline = a preview branch at migration head.** `db:new` diffs `DEV_DIRECT_URL` → `schema.prisma`. A freshly created preview branch is exactly at `main`'s migration head, so the diff yields precisely your new migration. **Keep the branch at head:** after generating each migration, `yarn db:apply` pushes it to the branch so the *next* diff is correct. (There is no local stack to diff against anymore.)
+
+**"Replays from empty" validation now happens on the branch, not locally.** A preview branch builds from an empty DB by running every file in `supabase/migrations` + `seed.sql` — the same proof `db:reset` used to give, now on the real target. A green branch creation = the migration replays cleanly.
+
+**Where data comes from.** The **persistent dev branch** gets real content via a one-time `pg_dump`/`pg_restore` from the dev DB (captured before retirement) — it lives in the branch's database, never in git. **Preview branches** are seeded from `supabase/seed.sql`, a small *synthetic* fixture (one demo organizer/event/ticket types) — so a fresh preview is testable without any PII. Keep `seed.sql` synthetic; real data never goes in it. See [ADR 0006](../adr/0006-hosted-branching-persistent-dev-branch.md).
+
+## Daily workflow after adoption
+
+**App / frontend change (no schema touch)** — nothing to install:
+```
+point apps/web/.env at the persistent dev branch (pooled + direct)
+edit code → run the app → open PR
+  → Vercel preview deploy (no DB change → still points at the dev branch, or its own preview branch)
+merge to main → dev branch + prod stay current
+```
+
+**Schema change** — via a preview branch:
+```
+open a PR (Branching auto-creates a preview branch)   # or: supabase branches create <name>
+point DEV_DIRECT_URL / DATABASE_URL at that branch
+edit apps/web/prisma/schema.prisma
+cd apps/web && yarn db:new add_promoter_payout_field   # diffs branch(at head) → schema → supabase/migrations/<ts>_*.sql
+# review the SQL, then apply it to the branch (keeps the branch at head + app testable):
+yarn db:apply
+git commit && push
+  → the preview branch replays all migrations + seed from empty (the "replays cleanly" proof)
+  → Vercel preview points at that branch DB automatically
+merge to main
+  → Supabase Branching applies the new migration to the production DB (and to the persistent dev branch)
+close/merge PR
+  → Supabase destroys the preview branch DB
+```
+
+## Testing a schema change against a preview branch
+
+There is **no local database** — schema changes are authored and tested against a remote preview branch, with your local app pointed at it. Database changes are rare, so the few minutes to provision a branch are an acceptable cost (see [ADR 0006](../adr/0006-hosted-branching-persistent-dev-branch.md)).
+
+```bash
+# 1. Spin up an isolated branch DB (built from supabase/migrations + seed.sql, at main's head)
+supabase link --project-ref <prod-ref>     # once per machine
+supabase branches create my-feature        # …or just open a PR — Branching creates one automatically
+
+# 2. Get the branch's connection details
+supabase branches get my-feature           # host/credentials (or read them from the dashboard)
+
+# 3. Point apps/web/.env at the branch
+#    DATABASE_URL   = <branch pooled 6543>
+#    DIRECT_URL     = <branch direct 5432>
+#    DEV_DIRECT_URL = <branch direct 5432>   # diff baseline
+
+# 4. Author + apply the migration
+#    edit apps/web/prisma/schema.prisma
+cd apps/web && yarn db:new my_change        # diffs branch(head) → schema → supabase/migrations/<ts>_my_change.sql
+yarn db:apply                               # push it to the branch (keeps branch at head + app testable)
+
+# 5. Run the app locally against the branch and verify
+yarn dev
+
+# 6. Commit + push. Tear down a manually-created branch when done:
+supabase branches delete my-feature         # PR-created branches auto-destroy on close
+```
+
+**Via a PR, steps 1/2/6 are automatic** — Branching creates and destroys the branch, and the Vercel preview is wired to it. You only do 3–5 (and can skip 3 entirely if testing through the preview deploy rather than a local server).
+
+## One-time setup checklist (manual — dashboard / secrets)
+
+- [ ] Supabase → **Integrations → GitHub**: connect the repo, set Supabase directory to `./supabase`, enable **Branching** (automatic branch on PR). This also enables auto-apply to **production** on merge to `main` — the documented prod-apply authority for this plan.
+- [ ] Create the **persistent dev branch** (tracks `main`): `supabase branches create dev --persistent` (no `--with-data` → no prod clone).
+- [ ] Load real data into the dev branch **once**, before retiring the old dev DB: `pg_dump "$DEV_DIRECT_URL" --data-only --no-owner --no-privileges --disable-triggers -Fc -f /tmp/dev-data.dump` → `pg_restore --data-only --no-owner --no-privileges --disable-triggers -d "<dev-branch-direct-url>" /tmp/dev-data.dump`.
+- [ ] Supabase → **Integrations → Vercel**: connect so PR preview deploys get their **preview branch** URLs automatically, and point the **dev/staging** deploy at the **persistent dev branch**. Confirm preview env vars are *branch-scoped*, prod stays on prod.
+- [ ] `apps/web/.env`: default profile points at the **persistent dev branch** (pooled + direct). When doing schema work, repoint `DATABASE_URL`/`DIRECT_URL`/`DEV_DIRECT_URL` at the PR's preview branch.
+- [ ] Retire the old standalone dev DB project once the persistent dev branch is serving traffic.
+
+## Risks / notes
+
+- **Authoring diff baseline:** `db:new` diffs `DEV_DIRECT_URL` → new schema. Point it at a **preview branch at migration head**, and `yarn db:apply` after each migration so the branch stays at head — otherwise the next diff regenerates already-authored migrations. (No local stack to diff against anymore.)
+- **Pooler vs direct:** migrations need the direct (5432) connection; the app uses the pooled (6543) one. Hence `directUrl`.
+- **Data sources** ([ADR 0006](../adr/0006-hosted-branching-persistent-dev-branch.md)): the persistent dev branch holds real data (one-time dev-DB restore, in the branch not git); preview branches get only the synthetic `seed.sql` fixture. Nothing real is committed or cloned into per-PR branches. The dev branch holds real records, so access-control it accordingly.
+- **Branching is billed** — the persistent dev branch (always-on) and every preview branch are real Postgres instances with cost. Preview branches are torn down on PR close; the dev branch runs continuously.
+- **Drizzle later:** when Prisma is replaced, only the *authoring* step changes (`drizzle-kit` emits SQL into `supabase/migrations`); branching is untouched.

--- a/docs/plans/2026-06-migrations-adoption.md
+++ b/docs/plans/2026-06-migrations-adoption.md
@@ -1,8 +1,8 @@
 ---
 title: Database Migrations Adoption
-status: proposed
+status: active
 created: 2026-06-02
-tracking-issue: TBD
+tracking-issue: #280
 ---
 
 # Database Migrations Adoption

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,413 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "troptix"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+# Controls whether new tables, views, sequences and functions created in the `public` schema by
+# `postgres` are reachable through the Data API roles (`anon`, `authenticated`, `service_role`)
+# without explicit GRANTs. Leave unset today to preserve local behaviour. The implicit default
+# flips to `false` on 2026-05-30 to match the new cloud default, and the field is removed in
+# 2026-10-30 once the always-revoked behaviour is permanent. Set to `false` to opt in early.
+# auto_expose_new_tables = false
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260603181353_init.sql
+++ b/supabase/migrations/20260603181353_init.sql
@@ -1,0 +1,249 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('PATRON', 'ORGANIZER', 'PROMOTER');
+
+-- CreateEnum
+CREATE TYPE "SocialMediaAccountType" AS ENUM ('UNKNOWN', 'FACEBOOK', 'INSTAGRAM', 'TIKTOK', 'TWITTER');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('AVAILABLE', 'NOT_AVAILABLE');
+
+-- CreateEnum
+CREATE TYPE "TicketType" AS ENUM ('FREE', 'PAID', 'COMPLEMENTARY');
+
+-- CreateEnum
+CREATE TYPE "OrderStatus" AS ENUM ('PENDING', 'CANCELLED', 'COMPLETED');
+
+-- CreateEnum
+CREATE TYPE "PromotionType" AS ENUM ('UNKNOWN', 'PERCENTAGE', 'DOLLAR_AMOUNT');
+
+-- CreateEnum
+CREATE TYPE "TicketFeeStructure" AS ENUM ('ABSORB_TICKET_FEES', 'PASS_TICKET_FEES');
+
+-- CreateEnum
+CREATE TYPE "DelegatedAccess" AS ENUM ('OWNER', 'TICKET_SCANNER');
+
+-- CreateTable
+CREATE TABLE "Users" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "firstName" TEXT,
+    "lastName" TEXT,
+    "stripeId" TEXT,
+    "role" "Role" NOT NULL DEFAULT 'PATRON',
+    "telephoneNumber" TEXT,
+    "billingAddress1" TEXT,
+    "billingAddress2" TEXT,
+    "billingCity" TEXT,
+    "billingCountry" TEXT,
+    "billingZip" TEXT,
+    "billingState" TEXT,
+
+    CONSTRAINT "Users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SocialMediaAccounts" (
+    "id" TEXT NOT NULL,
+    "socialMediaAccountType" "SocialMediaAccountType" NOT NULL DEFAULT 'UNKNOWN',
+    "link" TEXT,
+    "userId" TEXT,
+
+    CONSTRAINT "SocialMediaAccounts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Tickets" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3),
+    "status" "TicketStatus" NOT NULL DEFAULT 'NOT_AVAILABLE',
+    "ticketsType" "TicketType" DEFAULT 'PAID',
+    "fees" DOUBLE PRECISION,
+    "subtotal" DOUBLE PRECISION,
+    "total" DOUBLE PRECISION,
+    "firstName" TEXT,
+    "lastName" TEXT,
+    "email" TEXT,
+    "eventId" TEXT NOT NULL,
+    "orderId" TEXT NOT NULL,
+    "ticketTypeId" TEXT,
+    "userId" TEXT,
+
+    CONSTRAINT "Tickets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Orders" (
+    "id" TEXT NOT NULL,
+    "stripeCustomerId" TEXT,
+    "stripePaymentId" TEXT,
+    "createdAt" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3),
+    "total" DOUBLE PRECISION NOT NULL,
+    "subtotal" DOUBLE PRECISION,
+    "fees" DOUBLE PRECISION,
+    "name" TEXT,
+    "firstName" TEXT,
+    "lastName" TEXT,
+    "email" TEXT,
+    "cardType" TEXT,
+    "cardLast4" TEXT,
+    "telephoneNumber" TEXT,
+    "billingAddress1" TEXT,
+    "billingAddress2" TEXT,
+    "billingCity" TEXT,
+    "billingCountry" TEXT,
+    "billingZip" TEXT,
+    "billingState" TEXT,
+    "ticketsLink" TEXT,
+    "status" "OrderStatus" NOT NULL DEFAULT 'PENDING',
+    "userId" TEXT,
+    "eventId" TEXT NOT NULL,
+
+    CONSTRAINT "Orders_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Events" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "isDraft" BOOLEAN NOT NULL DEFAULT true,
+    "imageUrl" VARCHAR(2000),
+    "name" TEXT NOT NULL,
+    "description" VARCHAR(4000) NOT NULL,
+    "summary" TEXT,
+    "organizer" TEXT NOT NULL,
+    "organizerUserId" TEXT NOT NULL,
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "startTime" TIMESTAMP(3),
+    "endDate" TIMESTAMP(3) NOT NULL,
+    "endTime" TIMESTAMP(3),
+    "venue" TEXT,
+    "address" TEXT NOT NULL,
+    "country" TEXT,
+    "countryCode" TEXT,
+    "latitude" DOUBLE PRECISION,
+    "longitude" DOUBLE PRECISION,
+
+    CONSTRAINT "Events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Promotions" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "code" TEXT NOT NULL,
+    "promotionType" "PromotionType" NOT NULL DEFAULT 'UNKNOWN',
+    "value" DOUBLE PRECISION NOT NULL,
+    "eventId" TEXT,
+
+    CONSTRAINT "Promotions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TicketTypes" (
+    "id" TEXT NOT NULL,
+    "ticketType" "TicketType" DEFAULT 'PAID',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "maxPurchasePerUser" INTEGER NOT NULL,
+    "quantity" INTEGER NOT NULL,
+    "quantitySold" INTEGER DEFAULT 0,
+    "saleStartDate" TIMESTAMP(3) NOT NULL,
+    "saleStartTime" TIMESTAMP(3),
+    "saleEndDate" TIMESTAMP(3) NOT NULL,
+    "saleEndTime" TIMESTAMP(3),
+    "price" DOUBLE PRECISION NOT NULL,
+    "ticketingFees" "TicketFeeStructure" NOT NULL DEFAULT 'PASS_TICKET_FEES',
+    "eventId" TEXT NOT NULL,
+    "discountCode" TEXT,
+
+    CONSTRAINT "TicketTypes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DelegatedUsers" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "delegatedAccess" "DelegatedAccess" NOT NULL,
+    "email" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+
+    CONSTRAINT "DelegatedUsers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Users_email_key" ON "Users"("email");
+
+-- CreateIndex
+CREATE INDEX "SocialMediaAccounts_userId_idx" ON "SocialMediaAccounts"("userId");
+
+-- CreateIndex
+CREATE INDEX "Tickets_eventId_idx" ON "Tickets"("eventId");
+
+-- CreateIndex
+CREATE INDEX "Tickets_orderId_idx" ON "Tickets"("orderId");
+
+-- CreateIndex
+CREATE INDEX "Tickets_ticketTypeId_idx" ON "Tickets"("ticketTypeId");
+
+-- CreateIndex
+CREATE INDEX "Tickets_userId_idx" ON "Tickets"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Orders_stripePaymentId_key" ON "Orders"("stripePaymentId");
+
+-- CreateIndex
+CREATE INDEX "Orders_eventId_idx" ON "Orders"("eventId");
+
+-- CreateIndex
+CREATE INDEX "Orders_userId_idx" ON "Orders"("userId");
+
+-- CreateIndex
+CREATE INDEX "Promotions_eventId_idx" ON "Promotions"("eventId");
+
+-- CreateIndex
+CREATE INDEX "TicketTypes_eventId_idx" ON "TicketTypes"("eventId");
+
+-- CreateIndex
+CREATE INDEX "DelegatedUsers_eventId_idx" ON "DelegatedUsers"("eventId");
+
+-- AddForeignKey
+ALTER TABLE "SocialMediaAccounts" ADD CONSTRAINT "SocialMediaAccounts_userId_fkey" FOREIGN KEY ("userId") REFERENCES "Users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Tickets" ADD CONSTRAINT "Tickets_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Events"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Tickets" ADD CONSTRAINT "Tickets_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "Orders"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Tickets" ADD CONSTRAINT "Tickets_ticketTypeId_fkey" FOREIGN KEY ("ticketTypeId") REFERENCES "TicketTypes"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Tickets" ADD CONSTRAINT "Tickets_userId_fkey" FOREIGN KEY ("userId") REFERENCES "Users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Orders" ADD CONSTRAINT "Orders_userId_fkey" FOREIGN KEY ("userId") REFERENCES "Users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Orders" ADD CONSTRAINT "Orders_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Events"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Promotions" ADD CONSTRAINT "Promotions_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Events"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TicketTypes" ADD CONSTRAINT "TicketTypes_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Events"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DelegatedUsers" ADD CONSTRAINT "DelegatedUsers_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Events"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,35 @@
+-- Minimal seed fixture for FRESH preview branches (per-PR, schema-change DBs).
+--
+-- This is intentionally small + synthetic. Real dev data lives in the persistent
+-- dev branch, loaded once via a pg_dump/pg_restore from the dev DB (see
+-- docs/adr/0006-hosted-branching-persistent-dev-branch.md) — NOT here.
+-- Keep this file free of any production PII; it is committed and runs on every branch.
+
+-- Demo organizer
+insert into public."Users" (id, "createdAt", "updatedAt", email, name, "firstName", "lastName", role)
+values ('seed_org_1', now(), now(), 'demo-organizer@troptix.test', 'Demo Organizer', 'Demo', 'Organizer', 'ORGANIZER');
+
+-- Demo published event, owned by the demo organizer
+insert into public."Events" (
+  id, "createdAt", "updatedAt", "isDraft", name, description, summary,
+  organizer, "organizerUserId", "startDate", "endDate", venue, address, country, "countryCode"
+) values (
+  'seed_event_1', now(), now(), false,
+  'TropTix Demo Festival', 'A sample event seeded for preview branches.', 'Sample event for testing',
+  'Demo Organizer', 'seed_org_1',
+  '2026-08-15 18:00:00', '2026-08-15 23:00:00',
+  'Demo Arena', '123 Demo Street, Kingston', 'Jamaica', 'JM'
+);
+
+-- Ticket types for the demo event
+insert into public."TicketTypes" (
+  id, "ticketType", "createdAt", "updatedAt", name, description,
+  "maxPurchasePerUser", quantity, "quantitySold",
+  "saleStartDate", "saleEndDate", price, "ticketingFees", "eventId"
+) values
+  ('seed_tt_ga',  'PAID', now(), now(), 'General Admission', 'Standard entry',     10, 500, 0, now(), '2026-08-15 18:00:00', 25.00, 'PASS_TICKET_FEES', 'seed_event_1'),
+  ('seed_tt_vip', 'PAID', now(), now(), 'VIP',               'VIP entry with perks', 4,  50, 0, now(), '2026-08-15 18:00:00', 75.00, 'PASS_TICKET_FEES', 'seed_event_1');
+
+-- Demo promo code
+insert into public."Promotions" (id, "createdAt", "updatedAt", code, "promotionType", value, "eventId")
+values ('seed_promo_1', now(), now(), 'DEMO10', 'PERCENTAGE', 10, 'seed_event_1');


### PR DESCRIPTION
Part of #280.

Establishes a reviewable, replayable Supabase migrations pipeline for `apps/web`, replacing ad-hoc `prisma db push`.

## What's here (Phase 0–1)
- **`supabase/`** — `config.toml`, baseline migration `20260603181353_init.sql` (full current schema, verified reproducible from `schema.prisma`), and a small **synthetic** `seed.sql` fixture (demo organizer/event/ticket types — no PII).
- **`apps/web`** — `db:new` migration generator, `db:apply`, and `directUrl` on the Prisma datasource (direct 5432 for migrations, pooled 6543 for the app).
- **`docs/`** — the [migrations-adoption plan](docs/plans/2026-06-migrations-adoption.md) and ADRs:
  - 0004 — `supabase/migrations` as the schema source of truth
  - 0005 — local-only dev *(superseded)*
  - 0006 — hosted Supabase Branching: persistent dev branch + per-PR preview branches, no local Docker

## Expected workflow after this lands

**App / frontend change (no schema touch)** — nothing to install:
1. Point `apps/web/.env` at the **persistent dev branch** (always-on, real data).
2. Edit code, run the app, open a PR. Merge to `main` — dev branch and prod stay current.

**Schema change** — via a preview branch:
1. Open a PR (Branching auto-creates a preview branch) — or `supabase branches create <name>` manually.
2. Point `DATABASE_URL` / `DIRECT_URL` / `DEV_DIRECT_URL` at that branch.
3. Edit `apps/web/prisma/schema.prisma`, then `cd apps/web && yarn db:new <name>` — diffs the branch (at migration head) against the schema and writes `supabase/migrations/<ts>_<name>.sql`.
4. Review the SQL, then `yarn db:apply` to push it to the branch (keeps the branch at head + app testable).
5. Run the app against the branch to verify. The preview branch also replays all migrations + seed from empty — the "builds cleanly" proof.
6. Commit + push. On merge, **Supabase Branching applies the migration to prod** (and the dev branch); the preview branch is destroyed on PR close.

Notes: there is **no local Docker stack** — schema work happens on a remote preview branch (rare, so the provisioning time is acceptable). Prisma is only the SQL *generator*; `supabase/migrations/*.sql` is the source of truth, which survives the planned Prisma→Drizzle move. Full how-to in the [plan](docs/plans/2026-06-migrations-adoption.md#testing-a-schema-change-against-a-preview-branch).

## Already done out-of-band (prod)
Prod was baselined directly (not via this PR's CI): schema moved `troptix`→`public`, RLS enabled on all tables, migration history repaired to `20260603181353_init`. Drift check against prod is empty.

## Not in this PR
Phase 2 (Branching dashboard wiring — partially done) and Phase 3 (cut over) are tracked in #280.
