### PR TITLE
Add migration: enable RLS on all app tables

### DIFF
--- a/supabase/migrations/20260605205155_enable_rls.sql
+++ b/supabase/migrations/20260605205155_enable_rls.sql
@@ -1,0 +1,20 @@
+-- Enable Row Level Security on all application tables.
+--
+-- RLS was enabled on prod out-of-band during the troptix->public cutover but was
+-- never captured in a migration, so databases built from migrations (the persistent
+-- dev branch and every preview branch) had it off. This closes that gap: every
+-- environment becomes consistent, and prod is reproducible from migrations.
+--
+-- Idempotent: enabling RLS where it is already enabled is a no-op, so applying this
+-- to prod (already enabled) does nothing. With no policies defined, RLS denies
+-- anon/authenticated by default; the app connects as a role that bypasses RLS
+-- (postgres, rolbypassrls = true), so application access is unaffected.
+
+alter table public."Users"               enable row level security;
+alter table public."SocialMediaAccounts" enable row level security;
+alter table public."Events"              enable row level security;
+alter table public."Orders"              enable row level security;
+alter table public."Tickets"             enable row level security;
+alter table public."Promotions"          enable row level security;
+alter table public."TicketTypes"         enable row level security;
+alter table public."DelegatedUsers"      enable row level security;


### PR DESCRIPTION
Part of #280.

## What
Adds `supabase/migrations/20260605205155_enable_rls.sql` — `enable row level security` on all 8 app tables.

## Why
RLS was enabled on **prod** out-of-band during the `troptix`→`public` cutover, but never captured in a migration. So any database built *from migrations* — the persistent **dev branch** and every **preview branch** — has RLS **off** (the Supabase SQL editor flags this). This migration closes the gap:
- every environment gets RLS consistently
- prod becomes reproducible from migrations (not a manual snapshot)

## Safe to apply
- **Idempotent on prod** — enabling RLS where it's already on is a no-op.
- **App unaffected** — with no policies, RLS denies `anon`/`authenticated` by default, but the app connects as `postgres` (`rolbypassrls = true`), which bypasses RLS.

## Note
Hand-authored SQL, not `yarn db:new`-generated — Prisma can't model RLS, so a diff would be empty. This is `supabase/migrations` acting as the real source of truth (ADR 0004).
