### PR TITLE
Checkout rebuild (3/6): reservation primitives [Phase B1]

### DIFF
--- a/apps/web/src/server/lib/reservations.test.ts
+++ b/apps/web/src/server/lib/reservations.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Integration tests for the reservation primitives. These hit a REAL Postgres
+ * (the locking/atomicity behavior is not mockable), so point your env at the
+ * dev or a preview branch before running: `yarn test reservations`.
+ *
+ * Each test provisions its own ticket type and everything is cleaned up by event
+ * id in afterAll.
+ *
+ * @jest-environment node
+ */
+import prisma from '@/server/prisma';
+import { OrderStatus, ReservationStatus, TicketStatus } from '@prisma/client';
+import { generateId } from '@/lib/utils';
+import { confirm, expire, release, reserve } from './reservations';
+
+// Integration tests hit a real DB; the default 5s is too tight.
+jest.setTimeout(30_000);
+
+const TEST_EVENT_ID = `test-evt-${generateId()}`;
+const createdOrderIds: string[] = [];
+
+beforeAll(async () => {
+  await prisma.events.create({
+    data: {
+      id: TEST_EVENT_ID,
+      isDraft: false,
+      name: 'Reservation Test Event',
+      description: 'Fixture for reservations.test.ts',
+      organizer: 'Test Org',
+      organizerUserId: 'test-organizer',
+      startDate: new Date(),
+      endDate: new Date(Date.now() + 86_400_000),
+      address: '123 Test St',
+    },
+  });
+});
+
+afterAll(async () => {
+  // FK-safe teardown, scoped to the test event.
+  if (createdOrderIds.length > 0) {
+    await prisma.outboxMessage.deleteMany({
+      where: { OR: createdOrderIds.map((id) => ({ payload: { path: ['orderId'], equals: id } })) },
+    });
+  }
+  await prisma.tickets.deleteMany({ where: { eventId: TEST_EVENT_ID } });
+  await prisma.orders.deleteMany({ where: { eventId: TEST_EVENT_ID } });
+  await prisma.reservation.deleteMany({ where: { eventId: TEST_EVENT_ID } }); // items cascade
+  await prisma.ticketTypes.deleteMany({ where: { eventId: TEST_EVENT_ID } });
+  await prisma.events.delete({ where: { id: TEST_EVENT_ID } });
+  await prisma.$disconnect();
+});
+
+async function makeTicketType(capacity: number, priceCents = 1000) {
+  return prisma.ticketTypes.create({
+    data: {
+      id: generateId(),
+      name: 'GA',
+      description: 'General admission',
+      maxPurchasePerUser: 10,
+      quantity: capacity,
+      capacity,
+      price: priceCents / 100,
+      priceCents,
+      saleStartDate: new Date(Date.now() - 86_400_000),
+      saleEndDate: new Date(Date.now() + 86_400_000),
+      event: { connect: { id: TEST_EVENT_ID } },
+    },
+  });
+}
+
+describe('reserve — concurrency (the headline guarantee)', () => {
+  it('grants the last ticket exactly once under concurrent load', async () => {
+    const tt = await makeTicketType(1);
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        reserve({
+          eventId: TEST_EVENT_ID,
+          items: [{ ticketTypeId: tt.id, quantity: 1, unitPriceCents: 1000, feesCents: 0 }],
+        })
+      )
+    );
+
+    const totalGranted = results.reduce((sum, r) => sum + r.items[0].granted, 0);
+    expect(totalGranted).toBe(1);
+    expect(results.filter((r) => r.granted).length).toBe(1);
+
+    const after = await prisma.ticketTypes.findUnique({ where: { id: tt.id } });
+    expect(after?.reserved).toBe(1);
+    expect(after?.reserved).toBeLessThanOrEqual(after?.capacity ?? 0);
+  });
+});
+
+describe('reserve — clamp to available (wasAdjusted UX)', () => {
+  it('grants min(requested, available) and reports the reduction', async () => {
+    const tt = await makeTicketType(5);
+
+    const result = await reserve({
+      eventId: TEST_EVENT_ID,
+      items: [{ ticketTypeId: tt.id, quantity: 8, unitPriceCents: 1000, feesCents: 200 }],
+    });
+
+    expect(result.items[0].requested).toBe(8);
+    expect(result.items[0].granted).toBe(5);
+    expect(result.subtotalCents).toBe(5 * 1000);
+    expect(result.feesCents).toBe(5 * 200);
+    expect(result.totalCents).toBe(5 * 1200);
+
+    const after = await prisma.ticketTypes.findUnique({ where: { id: tt.id } });
+    expect(after?.reserved).toBe(5);
+  });
+});
+
+describe('confirm — atomic + idempotent', () => {
+  it('moves reserved→sold once and is a no-op on duplicate delivery', async () => {
+    const tt = await makeTicketType(5);
+    const r = await reserve({
+      eventId: TEST_EVENT_ID,
+      items: [{ ticketTypeId: tt.id, quantity: 2, unitPriceCents: 1500, feesCents: 300 }],
+      contact: { email: 'buyer@example.com', firstName: 'Bud', lastName: 'Buyer' },
+    });
+
+    // The route assigns the PaymentIntent id after creating the intent.
+    const paymentIntentId = `pi_test_${generateId()}`;
+    await prisma.reservation.update({
+      where: { id: r.reservationId },
+      data: { stripePaymentIntentId: paymentIntentId },
+    });
+
+    const first = await confirm({ paymentIntentId, cardType: 'visa', cardLast4: '4242' });
+    createdOrderIds.push(first.orderId);
+    expect(first.alreadyProcessed).toBe(false);
+
+    const second = await confirm({ paymentIntentId });
+    expect(second.alreadyProcessed).toBe(true);
+    expect(second.orderId).toBe(first.orderId);
+
+    const ttAfter = await prisma.ticketTypes.findUnique({ where: { id: tt.id } });
+    expect(ttAfter?.sold).toBe(2); // incremented once, not twice
+    expect(ttAfter?.reserved).toBe(0);
+
+    const orders = await prisma.orders.findMany({
+      where: { stripePaymentId: paymentIntentId },
+      include: { tickets: true },
+    });
+    expect(orders).toHaveLength(1);
+    expect(orders[0].status).toBe(OrderStatus.COMPLETED);
+    expect(orders[0].tickets).toHaveLength(2);
+    expect(orders[0].tickets.every((t) => t.status === TicketStatus.VALID)).toBe(true);
+
+    const resAfter = await prisma.reservation.findUnique({ where: { id: r.reservationId } });
+    expect(resAfter?.status).toBe(ReservationStatus.CONVERTED);
+    expect(resAfter?.orderId).toBe(first.orderId);
+  });
+});
+
+describe('release', () => {
+  it('hands held inventory back and marks the reservation RELEASED', async () => {
+    const tt = await makeTicketType(3);
+    const r = await reserve({
+      eventId: TEST_EVENT_ID,
+      items: [{ ticketTypeId: tt.id, quantity: 2, unitPriceCents: 1000, feesCents: 0 }],
+    });
+    expect((await prisma.ticketTypes.findUnique({ where: { id: tt.id } }))?.reserved).toBe(2);
+
+    const didRelease = await release(r.reservationId);
+    expect(didRelease).toBe(true);
+    expect((await prisma.ticketTypes.findUnique({ where: { id: tt.id } }))?.reserved).toBe(0);
+    expect((await prisma.reservation.findUnique({ where: { id: r.reservationId } }))?.status).toBe(
+      ReservationStatus.RELEASED
+    );
+
+    // idempotent: releasing again is a no-op
+    expect(await release(r.reservationId)).toBe(false);
+  });
+});
+
+describe('expire', () => {
+  it('releases inventory held by reservations past their TTL', async () => {
+    const tt = await makeTicketType(4);
+    const r = await reserve({
+      eventId: TEST_EVENT_ID,
+      items: [{ ticketTypeId: tt.id, quantity: 3, unitPriceCents: 1000, feesCents: 0 }],
+      ttlMinutes: -1, // already expired
+    });
+    expect((await prisma.ticketTypes.findUnique({ where: { id: tt.id } }))?.reserved).toBe(3);
+
+    const count = await expire(new Date());
+    expect(count).toBeGreaterThanOrEqual(1);
+
+    expect((await prisma.ticketTypes.findUnique({ where: { id: tt.id } }))?.reserved).toBe(0);
+    expect((await prisma.reservation.findUnique({ where: { id: r.reservationId } }))?.status).toBe(
+      ReservationStatus.EXPIRED
+    );
+  });
+});

--- a/apps/web/src/server/lib/reservations.ts
+++ b/apps/web/src/server/lib/reservations.ts
@@ -74,23 +74,8 @@ export async function reserve(input: ReserveInput): Promise<ReserveResult> {
   const reservationId = generateId();
 
   return prisma.$transaction(async (tx) => {
-    await tx.reservation.create({
-      data: {
-        id: reservationId,
-        status: ReservationStatus.HELD,
-        expiresAt,
-        email: input.contact?.email ?? null,
-        firstName: input.contact?.firstName ?? null,
-        lastName: input.contact?.lastName ?? null,
-        totalCents: 0,
-        subtotalCents: 0,
-        feesCents: 0,
-        event: { connect: { id: input.eventId } },
-        ...(input.userId ? { user: { connect: { id: input.userId } } } : {}),
-      },
-    });
-
     const grantedItems: ReserveGrantedItem[] = [];
+    const itemRows: Prisma.ReservationItemCreateManyReservationInput[] = [];
     let subtotalCents = 0;
     let feesCents = 0;
 
@@ -120,15 +105,12 @@ export async function reserve(input: ReserveInput): Promise<ReserveResult> {
       }
 
       if (granted > 0) {
-        await tx.reservationItem.create({
-          data: {
-            id: generateId(),
-            reservationId,
-            ticketTypeId: item.ticketTypeId,
-            quantity: granted,
-            unitPriceCents: item.unitPriceCents,
-            feesCents: item.feesCents,
-          },
+        itemRows.push({
+          id: generateId(),
+          ticketTypeId: item.ticketTypeId,
+          quantity: granted,
+          unitPriceCents: item.unitPriceCents,
+          feesCents: item.feesCents,
         });
         subtotalCents += granted * item.unitPriceCents;
         feesCents += granted * item.feesCents;
@@ -139,9 +121,22 @@ export async function reserve(input: ReserveInput): Promise<ReserveResult> {
 
     const totalCents = subtotalCents + feesCents;
 
-    await tx.reservation.update({
-      where: { id: reservationId },
-      data: { subtotalCents, feesCents, totalCents },
+    // One write: create the hold with its items and final totals already known.
+    await tx.reservation.create({
+      data: {
+        id: reservationId,
+        status: ReservationStatus.HELD,
+        expiresAt,
+        email: input.contact?.email ?? null,
+        firstName: input.contact?.firstName ?? null,
+        lastName: input.contact?.lastName ?? null,
+        subtotalCents,
+        feesCents,
+        totalCents,
+        event: { connect: { id: input.eventId } },
+        ...(input.userId ? { user: { connect: { id: input.userId } } } : {}),
+        items: { createMany: { data: itemRows } },
+      },
     });
 
     return {
@@ -209,8 +204,10 @@ export async function confirm(input: ConfirmInput): Promise<ConfirmResult> {
     const orderType = isFree ? OrderType.FREE : OrderType.PAID;
     const ticketsType = isFree ? TicketType.FREE : TicketType.PAID;
 
-    // reserved → sold. Dual-write the legacy `quantitySold` until Phase C swaps
-    // the organizer dashboard read to `sold` (plan decision #3).
+    // In one pass per item: move reserved → sold (dual-writing the legacy
+    // `quantitySold` until Phase C swaps the dashboard read to `sold`), and
+    // build one VALID ticket row per reserved unit.
+    const ticketRows: Prisma.TicketsCreateManyOrderInput[] = [];
     for (const item of reservation.items) {
       await tx.ticketTypes.update({
         where: { id: item.ticketTypeId },
@@ -220,12 +217,9 @@ export async function confirm(input: ConfirmInput): Promise<ConfirmResult> {
           quantitySold: { increment: item.quantity },
         },
       });
-    }
 
-    // One ticket row per reserved unit.
-    const ticketRows: Prisma.TicketsCreateManyOrderInput[] =
-      reservation.items.flatMap((item) =>
-        Array.from({ length: item.quantity }, () => ({
+      for (let i = 0; i < item.quantity; i++) {
+        ticketRows.push({
           id: generateId(),
           status: TicketStatus.VALID,
           ticketsType,
@@ -238,8 +232,9 @@ export async function confirm(input: ConfirmInput): Promise<ConfirmResult> {
           eventId: reservation.eventId,
           ticketTypeId: item.ticketTypeId,
           ...(reservation.userId ? { userId: reservation.userId } : {}),
-        }))
-      );
+        });
+      }
+    }
 
     const orderId = generateId();
     await tx.orders.create({

--- a/apps/web/src/server/lib/reservations.ts
+++ b/apps/web/src/server/lib/reservations.ts
@@ -1,0 +1,343 @@
+/**
+ * Reservation-based inventory primitives (roadmap reservation rebuild, Phase B).
+ *
+ * The only operation that needs a database-level atomicity guarantee is the
+ * inventory hold; it is a single race-safe SQL statement (see `reserve`). The
+ * rest (`confirm` / `release` / `expire`) are ordinary Prisma transactions — no
+ * stored procedures (ADR 0007).
+ */
+import prisma from '@/server/prisma';
+import {
+  OrderStatus,
+  OrderType,
+  Prisma,
+  ReservationStatus,
+  TicketStatus,
+  TicketType,
+} from '@prisma/client';
+import { generateId } from '@/lib/utils';
+
+const DEFAULT_TTL_MINUTES = 10;
+
+export interface ReserveItemInput {
+  ticketTypeId: string;
+  /** Requested quantity — already clamped to maxPurchasePerUser / sale window by the caller. */
+  quantity: number;
+  unitPriceCents: number;
+  feesCents: number;
+}
+
+export interface ReserveInput {
+  eventId: string;
+  items: ReserveItemInput[];
+  contact?: {
+    email?: string | null;
+    firstName?: string | null;
+    lastName?: string | null;
+  };
+  userId?: string | null;
+  ttlMinutes?: number;
+}
+
+export interface ReserveGrantedItem {
+  ticketTypeId: string;
+  requested: number;
+  granted: number;
+}
+
+export interface ReserveResult {
+  reservationId: string;
+  items: ReserveGrantedItem[];
+  subtotalCents: number;
+  feesCents: number;
+  totalCents: number;
+  expiresAt: Date;
+  /** True if any quantity was granted; false ⇒ everything was sold out. */
+  granted: boolean;
+}
+
+/**
+ * Atomically hold inventory for a set of ticket types.
+ *
+ * Per item, one race-safe statement clamps the grant to availability
+ * (`capacity - reserved - sold`) and increments `reserved`. The `FOR UPDATE`
+ * in the CTE serializes concurrent buyers of the same ticket type, so the last
+ * ticket can never be granted twice. Returns the granted-per-item breakdown so
+ * the caller can surface a "we reduced your quantity" (wasAdjusted) message.
+ *
+ * Business rules (maxPurchasePerUser, sale window, password gating) are the
+ * caller's responsibility — this is purely the inventory hold.
+ */
+export async function reserve(input: ReserveInput): Promise<ReserveResult> {
+  const ttlMinutes = input.ttlMinutes ?? DEFAULT_TTL_MINUTES;
+  const expiresAt = new Date(Date.now() + ttlMinutes * 60_000);
+  const reservationId = generateId();
+
+  return prisma.$transaction(async (tx) => {
+    await tx.reservation.create({
+      data: {
+        id: reservationId,
+        status: ReservationStatus.HELD,
+        expiresAt,
+        email: input.contact?.email ?? null,
+        firstName: input.contact?.firstName ?? null,
+        lastName: input.contact?.lastName ?? null,
+        totalCents: 0,
+        subtotalCents: 0,
+        feesCents: 0,
+        event: { connect: { id: input.eventId } },
+        ...(input.userId ? { user: { connect: { id: input.userId } } } : {}),
+      },
+    });
+
+    const grantedItems: ReserveGrantedItem[] = [];
+    let subtotalCents = 0;
+    let feesCents = 0;
+
+    for (const item of input.items) {
+      const requested = Math.max(0, Math.floor(item.quantity));
+      let granted = 0;
+
+      if (requested > 0) {
+        // Lock the ticket-type row, clamp the grant to current availability,
+        // and increment reserved — all in one statement. GREATEST/LEAST keep
+        // the grant within [0, available]; a NULL capacity (pre-cutover) yields
+        // availability 0, so it simply can't oversell.
+        const rows = await tx.$queryRaw<Array<{ granted: number }>>(Prisma.sql`
+          WITH locked AS (
+            SELECT id, GREATEST("capacity" - "reserved" - "sold", 0) AS avail
+            FROM "TicketTypes"
+            WHERE id = ${item.ticketTypeId}
+            FOR UPDATE
+          )
+          UPDATE "TicketTypes" t
+          SET "reserved" = t."reserved" + LEAST(${requested}::int, locked.avail)
+          FROM locked
+          WHERE t.id = locked.id
+          RETURNING LEAST(${requested}::int, locked.avail)::int AS granted
+        `);
+        granted = rows[0]?.granted ?? 0;
+      }
+
+      if (granted > 0) {
+        await tx.reservationItem.create({
+          data: {
+            id: generateId(),
+            reservationId,
+            ticketTypeId: item.ticketTypeId,
+            quantity: granted,
+            unitPriceCents: item.unitPriceCents,
+            feesCents: item.feesCents,
+          },
+        });
+        subtotalCents += granted * item.unitPriceCents;
+        feesCents += granted * item.feesCents;
+      }
+
+      grantedItems.push({ ticketTypeId: item.ticketTypeId, requested, granted });
+    }
+
+    const totalCents = subtotalCents + feesCents;
+
+    await tx.reservation.update({
+      where: { id: reservationId },
+      data: { subtotalCents, feesCents, totalCents },
+    });
+
+    return {
+      reservationId,
+      items: grantedItems,
+      subtotalCents,
+      feesCents,
+      totalCents,
+      expiresAt,
+      granted: grantedItems.some((g) => g.granted > 0),
+    };
+  });
+}
+
+export interface ConfirmInput {
+  paymentIntentId: string;
+  cardType?: string | null;
+  cardLast4?: string | null;
+}
+
+export interface ConfirmResult {
+  orderId: string;
+  /** True when this was a duplicate webhook delivery (no-op). */
+  alreadyProcessed: boolean;
+}
+
+/**
+ * Materialize a paid (or free) order from a held reservation, atomically:
+ * move `reserved → sold`, create the Order + one Ticket per unit (VALID), mark
+ * the reservation CONVERTED, and enqueue the confirmation email in the outbox
+ * (sent after commit — never inside this transaction).
+ *
+ * Idempotent: Stripe delivers webhooks at-least-once, so a second call for an
+ * already-CONVERTED reservation is a no-op returning the existing order id.
+ */
+export async function confirm(input: ConfirmInput): Promise<ConfirmResult> {
+  return prisma.$transaction(async (tx) => {
+    const reservation = await tx.reservation.findUnique({
+      where: { stripePaymentIntentId: input.paymentIntentId },
+      include: { items: true },
+    });
+
+    if (!reservation) {
+      throw new Error(
+        `No reservation found for payment intent ${input.paymentIntentId}`
+      );
+    }
+
+    if (reservation.status === ReservationStatus.CONVERTED) {
+      if (!reservation.orderId) {
+        throw new Error(
+          `Reservation ${reservation.id} is CONVERTED but has no orderId`
+        );
+      }
+      return { orderId: reservation.orderId, alreadyProcessed: true };
+    }
+
+    if (reservation.status !== ReservationStatus.HELD) {
+      throw new Error(
+        `Reservation ${reservation.id} is ${reservation.status}; cannot confirm`
+      );
+    }
+
+    const isFree = reservation.totalCents === 0;
+    const orderType = isFree ? OrderType.FREE : OrderType.PAID;
+    const ticketsType = isFree ? TicketType.FREE : TicketType.PAID;
+
+    // reserved → sold. Dual-write the legacy `quantitySold` until Phase C swaps
+    // the organizer dashboard read to `sold` (plan decision #3).
+    for (const item of reservation.items) {
+      await tx.ticketTypes.update({
+        where: { id: item.ticketTypeId },
+        data: {
+          reserved: { decrement: item.quantity },
+          sold: { increment: item.quantity },
+          quantitySold: { increment: item.quantity },
+        },
+      });
+    }
+
+    // One ticket row per reserved unit.
+    const ticketRows: Prisma.TicketsCreateManyOrderInput[] =
+      reservation.items.flatMap((item) =>
+        Array.from({ length: item.quantity }, () => ({
+          id: generateId(),
+          status: TicketStatus.VALID,
+          ticketsType,
+          subtotal: item.unitPriceCents / 100,
+          fees: item.feesCents / 100,
+          total: (item.unitPriceCents + item.feesCents) / 100,
+          firstName: reservation.firstName,
+          lastName: reservation.lastName,
+          email: reservation.email,
+          eventId: reservation.eventId,
+          ticketTypeId: item.ticketTypeId,
+          ...(reservation.userId ? { userId: reservation.userId } : {}),
+        }))
+      );
+
+    const orderId = generateId();
+    await tx.orders.create({
+      data: {
+        id: orderId,
+        status: OrderStatus.COMPLETED,
+        type: orderType,
+        stripePaymentId: input.paymentIntentId,
+        total: reservation.totalCents / 100,
+        subtotal: reservation.subtotalCents / 100,
+        fees: reservation.feesCents / 100,
+        totalCents: reservation.totalCents,
+        subtotalCents: reservation.subtotalCents,
+        feesCents: reservation.feesCents,
+        firstName: reservation.firstName,
+        lastName: reservation.lastName,
+        email: reservation.email,
+        cardType: input.cardType ?? null,
+        cardLast4: input.cardLast4 ?? null,
+        event: { connect: { id: reservation.eventId } },
+        ...(reservation.userId
+          ? { user: { connect: { id: reservation.userId } } }
+          : {}),
+        tickets: { createMany: { data: ticketRows } },
+      },
+    });
+
+    await tx.reservation.update({
+      where: { id: reservation.id },
+      data: { status: ReservationStatus.CONVERTED, orderId },
+    });
+
+    await tx.outboxMessage.create({
+      data: {
+        id: generateId(),
+        type: 'order_confirmation',
+        payload: { orderId },
+      },
+    });
+
+    return { orderId, alreadyProcessed: false };
+  });
+}
+
+/**
+ * Release a single HELD reservation's inventory and mark it `toStatus`.
+ * Returns false if the reservation isn't HELD (already converted/released/
+ * expired) — making release/expire idempotent and safe against double runs.
+ */
+async function releaseHeldInTx(
+  tx: Prisma.TransactionClient,
+  reservationId: string,
+  toStatus: ReservationStatus
+): Promise<boolean> {
+  const reservation = await tx.reservation.findUnique({
+    where: { id: reservationId },
+    include: { items: true },
+  });
+  if (!reservation || reservation.status !== ReservationStatus.HELD) {
+    return false;
+  }
+  for (const item of reservation.items) {
+    await tx.ticketTypes.update({
+      where: { id: item.ticketTypeId },
+      data: { reserved: { decrement: item.quantity } },
+    });
+  }
+  await tx.reservation.update({
+    where: { id: reservationId },
+    data: { status: toStatus },
+  });
+  return true;
+}
+
+/** Hand a held reservation's inventory back (e.g. user abandons checkout). */
+export async function release(reservationId: string): Promise<boolean> {
+  return prisma.$transaction((tx) =>
+    releaseHeldInTx(tx, reservationId, ReservationStatus.RELEASED)
+  );
+}
+
+/**
+ * Release inventory held by all HELD reservations past their TTL. Called by the
+ * cron. Idempotent and concurrency-safe (each release re-checks status in its
+ * own transaction). Returns the number of reservations expired.
+ */
+export async function expire(now: Date = new Date()): Promise<number> {
+  const expired = await prisma.reservation.findMany({
+    where: { status: ReservationStatus.HELD, expiresAt: { lt: now } },
+    select: { id: true },
+  });
+
+  let count = 0;
+  for (const { id } of expired) {
+    const released = await prisma.$transaction((tx) =>
+      releaseHeldInTx(tx, id, ReservationStatus.EXPIRED)
+    );
+    if (released) count++;
+  }
+  return count;
+}

--- a/docs/plans/2026-06-checkout-reservation-rebuild.md
+++ b/docs/plans/2026-06-checkout-reservation-rebuild.md
@@ -29,13 +29,13 @@ Rather than three patches (a `FOR UPDATE` lock thrown away once reservations lan
 
 ### 1. Inventory: counter columns + atomic conditional decrement
 
-Replace `quantitySold` with `capacity` (immutable total, rename of `quantity`), `reserved` (held by active reservations), `sold` (confirmed). **availability = `capacity − reserved − sold`**, read directly. Reserve is a single atomic statement inside a Postgres function:
+Replace `quantitySold` with `capacity` (immutable total, rename of `quantity`), `reserved` (held by active reservations), `sold` (confirmed). **availability = `capacity − reserved − sold`**, read directly. Reserve is a single atomic statement issued inline from app code (no stored procedure):
 ```sql
 UPDATE "TicketTypes"
 SET reserved = reserved + :qty
 WHERE id = :id AND (capacity - reserved - sold) >= :qty;  -- 0 rows => insufficient stock
 ```
-Correct at READ COMMITTED — **structurally eliminates bug 1.1**, no lock or retry loop. The function clamps to available per type and returns granted quantities, preserving the "wasAdjusted" UX.
+Correct at READ COMMITTED — **structurally eliminates bug 1.1**, no lock or retry loop. `reserve()` clamps to available per type and returns granted quantities, preserving the "wasAdjusted" UX.
 
 ### 2. Explicit reservation, not a PENDING order
 
@@ -49,19 +49,26 @@ ReservationItem { id, reservationId, ticketTypeId, quantity, unitPriceCents, fee
 
 ### 3. Payment confirmation: single source of truth, atomic + idempotent
 
-`confirm_reservation()` in one transaction: find HELD reservation by payment-intent id (**already CONVERTED → no-op**, the idempotency guard for Stripe's at-least-once delivery); `reserved -= q; sold += q` per item; create `Order` + `OrderTicket`s (status VALID); mark reservation CONVERTED; insert an outbox row for the confirmation email (sent after commit / by cron drain — never inside the txn). **Eliminates bug 1.2** and the double-increment hazard.
+`confirm()` — a Prisma `$transaction` in `reservations.ts` (not a stored procedure): find HELD reservation by payment-intent id (**already CONVERTED → no-op**, the idempotency guard for Stripe's at-least-once delivery); `reserved -= q; sold += q` per item; create `Order` + `OrderTicket`s (status VALID); mark reservation CONVERTED; insert an outbox row for the confirmation email (sent after commit / by cron drain — never inside the txn). **Eliminates bug 1.2** and the double-increment hazard.
 
 ### 4. Expiry releases inventory
 
-`expire_reservations(now)` (called by the repurposed cron): for each HELD reservation past `expiresAt`, `reserved -= q` per item, mark EXPIRED. Idempotent; lazy release on read supported.
+`expire(now)` (a Prisma transaction called by the repurposed cron): for each HELD reservation past `expiresAt`, `reserved -= q` per item, mark EXPIRED. Idempotent; lazy release on read supported.
 
 ### 5. Stripe client
 
 New `apps/web/src/server/lib/stripe.ts`: one shared client, `apiVersion: '2023-10-16'` (matches installed `stripe@14.25.0` `LatestApiVersion` — drops every `@ts-ignore`). Idempotency key = reservation id on `paymentIntents.create`. **Eliminates bug 1.3.** Leave the ephemeral-key `2020-08-27` (`pages/api/stripe/index.ts:99`) independent — it must match the mobile Stripe SDK.
 
-### 6. Postgres functions (concurrency-critical core)
+### 6. The atomic hold — no stored procedures
 
-Authored as hand-written SQL inside a Supabase migration (`supabase/migrations/<ts>_*.sql`), appended after the `db:new`-generated DDL since Prisma cannot express functions. Called from app code via `$queryRaw`/`$executeRaw`: `reserve_tickets`, `confirm_reservation`, `release_reservation`, `expire_reservations`.
+The only operation needing a database-level atomicity guarantee is the inventory hold, and it is a single conditional `UPDATE` issued inline from app code (no plpgsql):
+
+```sql
+UPDATE "TicketTypes" SET "reserved" = "reserved" + $n
+WHERE id = $id AND "capacity" - "reserved" - "sold" >= $n;   -- 0 rows ⇒ sold out
+```
+
+Atomic at READ COMMITTED — the `UPDATE` row-locks and re-checks the predicate against the committed row, so two concurrent buyers of the last ticket can't both win. A multi-item reservation runs one such `UPDATE` per ticket type inside a single Prisma `$transaction`; if any affects 0 rows the whole transaction rolls back. `reserve` / `confirm` / `release` / `expire` all live in `server/lib/reservations.ts` as Prisma transactions — typed and unit-testable, not plpgsql. See [ADR 0007](../adr/0007-reservation-based-checkout.md).
 
 ### 7. Schema corrections the checkout depends on
 
@@ -71,7 +78,6 @@ Authored as hand-written SQL inside a Supabase migration (`supabase/migrations/<
 | `startsAt`/`endsAt`, `saleStartsAt`/`saleEndsAt` | Reservation checks the sale window; split date/time today **ignores the time** (`initiate/route.ts:394`) — a real bug. |
 | Ticket statuses → `VALID`/`USED`/`CANCELLED`/`REFUNDED` + `checkinTimestamp` | `AVAILABLE`/`NOT_AVAILABLE` is overloaded (unpaid vs scanned); scan/check-in toggles the same flag. |
 | Order-level `type` (FREE/PAID/COMPLEMENTARY) | One reservation→confirm path for all order kinds. |
-| `Orders.createdAt` non-nullable | Expiry depends on it. |
 
 **Deferred** (companion rename sweep, no behavior change): table/field renames, dropping dead tables, `discountCode`→`password`, `organizer`→`hostName`, dropping redundant `name`.
 
@@ -79,28 +85,39 @@ Authored as hand-written SQL inside a Supabase migration (`supabase/migrations/<
 
 ## Files & Consumers
 
-**New:** `apps/web/src/server/lib/stripe.ts` (shipped in PR #279); `apps/web/src/server/lib/reservations.ts` (TS wrappers over the SQL functions); Supabase migrations under `supabase/migrations/` (additive, then cleanup) carrying the DDL + functions + backfill.
+**New:** `apps/web/src/server/lib/stripe.ts` (shipped, PR #279); `apps/web/src/server/lib/reservations.ts` — `reserve`/`confirm`/`release`/`expire` as Prisma transactions (the hold is an inline conditional `UPDATE`); Supabase migrations under `supabase/migrations/` — DDL + RLS only (additive in Phase A; the data backfill happens at cutover; drops in cleanup), no functions.
 
 **Checkout path:**
-- `app/api/checkout/initiate/route.ts` → "create reservation": call `reserve_tickets`, create PaymentIntent (idempotency key = reservation id), return `clientSecret` + `reservationId` + granted quantities. Delete PENDING-order creation, `validateTicketType` stock math, `getPrismaCreateOrderPayload`. Free orders run reservation→`confirm_reservation` immediately.
-- `app/api/checkout/config/route.ts`, `app/api/checkout/apply-code/route.ts` → availability = `capacity − reserved − sold` (drop order-counting).
-- `pages/api/stripe/webhook.ts` → call `confirm_reservation`; email from outbox after commit. (Stays in Pages Router; App-Router move is P3.2.) Retire the `orderHelper` increment helpers.
-- `app/api/cron/invalidate-orders/route.ts` → call `expire_reservations`; optionally drain the outbox.
+- `app/api/checkout/initiate/route.ts` → "create reservation": call `reserve()`, create PaymentIntent (idempotency key = reservation id), return `reservationId` + `clientSecret` + granted quantities. Delete PENDING-order creation, `validateTicketType` stock math, `getPrismaCreateOrderPayload`. Free orders run `reserve()` → `confirm()` synchronously.
+- `app/api/checkout/config/route.ts`, `app/api/checkout/apply-code/route.ts` → availability = `capacity − reserved − sold` (drop order-counting). Response shape unchanged.
+- **New** `app/api/stripe/webhook/route.ts` (App Router; raw body via `req.text()`, drops `micro`) → `confirm()`; idempotency via `ProcessedStripeEvent`; email from outbox after commit; `payment_failed` → `release()`. **Delete** the Pages-Router `pages/api/stripe/webhook.ts` + the `orderHelper` increment helpers.
+- `app/api/cron/invalidate-orders/route.ts` → call `expire()` (releases held inventory) + drain the outbox.
 
 **Organizer reads:**
 - `getEventOverview.ts` + tickets page → read `sold` (+ optionally `reserved`); revenue from completed Orders.
 - `app/api/organizer/tickets/scan/route.ts`, `check-in/route.ts` → set `USED` + `checkinTimestamp`.
 - Complementary tickets (`orderHelper.ts:113`) → reservation of `type=COMPLEMENTARY` incrementing `sold`.
 
-**Client (mostly unchanged):** `CheckoutContainer.tsx` / `payment-form.tsx` keep Stripe Elements `confirmPayment`; hold `reservationId` until confirmation; confirmation page resolves the order from the converted reservation.
+**Client:** `CheckoutContainer.tsx` / `payment-form.tsx` keep Stripe Elements `confirmPayment` but hold a **`reservationId`** (not an order id), since the Order is materialized only on webhook `confirm`. Post-payment URLs key off the reservation. The **confirmation page** is already async-safe (reads Stripe PaymentIntent state, no DB lookup). The **receipt + order-details pages** look the order up synchronously today and 404 if missing — they must instead resolve the order via the reservation and **poll / show a "processing" state until the webhook converts it** (the order page already has a "Hold tight, processing" state to reuse).
 
 ---
 
 ## Phases (one PR each)
 
 - **PR 1 — Shared Stripe client (shipped, PR #279).** One `server/lib/stripe.ts` pinned to `2023-10-16`, replacing three ad-hoc clients; root fix for bug 1.3.
-- **Phase A — Schema + functions foundation (no behavior change).** Authored through the Supabase migrations pipeline against a per-PR **preview branch** (no local DB): edit `schema.prisma` → `yarn db:new checkout_reservation_foundation` generates the table/column DDL → **hand-append** to the migration the RLS-enable for the new tables, the data backfill, and the `CREATE FUNCTION` statements → `yarn db:apply` to the branch → verify the branch replays cleanly. Adds columns (`capacity`/`reserved`/`sold`, `*Cents`, `startsAt`/`endsAt`/`saleStartsAt`/`saleEndsAt`, order `type`, `checkinTimestamp`, new status enum values), new tables (`Reservation`, `ReservationItem`, `OutboxMessage`, optional `ProcessedStripeEvent` — all with RLS enabled per the #281 convention), and the Postgres functions. Backfill: `sold = quantitySold`; `capacity = quantity`; `*Cents = round(price*100)`; `startsAt = startDate (+ startTime)`; status mapping. Old columns retained (additive ⇒ all new columns nullable or defaulted). Also stand up the jest harness (jest is referenced in `package.json` but not installed).
-- **Phase B — Cut over checkout.** Switch initiate/config/apply-code/webhook/cron to the reservation model. **`reserved` seeded from in-flight PENDING holds at cutover** (the one genuine risk) — deploy in a low-traffic window with a brief checkout pause during seed+switch. Full test suite here.
+- **Phase A — Schema foundation (shipped, PR #284).** Additive `schema.prisma` (new columns `capacity`/`reserved`/`sold`, `*Cents`, `startsAt`/`endsAt`/`saleStartsAt`/`saleEndsAt`, order `type`, `checkinTimestamp`, new `TicketStatus` values; new tables `Reservation`/`ReservationItem`/`OutboxMessage`/`ProcessedStripeEvent`) generated via `yarn db:new`, with RLS on the new tables hand-appended (per the #281 convention). **No stored functions, no backfill** (deferred to the cutover). Old columns retained; all new columns nullable or defaulted ⇒ behavior-neutral.
+- **Phase B — Cut over checkout (fixes 1.1 + 1.2).** The live-flow change. **Headline contract change:** the Order is materialized only on webhook `confirm`, so `/initiate` returns a `reservationId` and post-payment pages key off it (see *Client*, above). Split into reviewable sub-PRs:
+  - **B1** — `server/lib/reservations.ts` (`reserve`/`confirm`/`release`/`expire`) + jest harness (jest is referenced in `package.json` but not installed) + concurrency / idempotency / expire tests against the preview branch. *(isolated, no wiring — safest first)*
+  - **B2** — server cutover: `/initiate` → `reserve()`; `/config` + `/apply-code` → `capacity − reserved − sold`; webhook → App Router + `confirm()`; cron → `expire()`.
+  - **B3** — client: reservation-aware URLs + receipt/order polling.
+  - **B4** — cutover migration (backfill `sold ← quantitySold` + the static columns; seed `reserved` from in-flight PENDING holds) + the operational runbook.
+
+  **Decisions:**
+  1. **Async order id** — post-payment URLs use `reservationId`; receipt/order resolve the order via the reservation and poll while it's unconverted. Confirmation page unchanged (already async-safe).
+  2. **Reservation TTL** — 10 minutes (the client may show a countdown).
+  3. **Dashboard during transition** — `confirm()` dual-writes `quantitySold` alongside `sold`, so the organizer dashboard stays correct until Phase C swaps its read to `sold`. Keeps B and C decoupled.
+  4. **Idempotency** — `ProcessedStripeEvent` (Stripe event id) **and** the reservation-status guard (both; cheap).
+  5. **Cutover runbook** — run B4's sweep in a brief checkout-pause window so there are ~no in-flight PENDING orders to migrate; then deploy + resume. `reserved` is seeded then — the one genuine risk.
 - **Phase C — Organizer reads.** Dashboard, scan/check-in, complementary path move to new columns/statuses.
 - **Phase D — Cleanup.** Drop `quantitySold`/`quantity`/`price`/`startDate`/`startTime`/old statuses; remove dead code. Optional deferred rename sweep.
 
@@ -108,8 +125,8 @@ Authored as hand-written SQL inside a Supabase migration (`supabase/migrations/<
 
 ## Verification
 
-- **Concurrency (headline):** integration test against the PR's **Supabase preview branch** (a real Postgres) — N concurrent `reserve_tickets` for `capacity = 1`; assert exactly one grant, `reserved` never exceeds `capacity`.
-- **Idempotency:** `confirm_reservation` twice for one payment intent → `sold` increments once, one Order.
+- **Concurrency (headline):** integration test against the PR's **Supabase preview branch** (a real Postgres) — N concurrent `reserve()` for `capacity = 1`; assert exactly one grant, `reserved` never exceeds `capacity`.
+- **Idempotency:** `confirm()` twice for one payment intent → `sold` increments once, one Order.
 - **Expiry:** HELD reservation past `expiresAt` → `reserved` released, status EXPIRED.
 - **Money:** cents round-trips with Stripe amounts (no float drift).
 - **Sale window:** ticket with `saleStartsAt` later today is unavailable now.
@@ -118,4 +135,4 @@ Authored as hand-written SQL inside a Supabase migration (`supabase/migrations/<
 
 ## Out of scope
 
-Drizzle (P4.1), Supabase Auth (P4.2), webhook → App Router (P3.2), full transactional email service (P4.4 — minimal outbox only), Stripe Connect, cosmetic renames. The design is forward-compatible with each.
+Drizzle (P4.1), Supabase Auth (P4.2), full transactional email service (P4.4 — minimal outbox only), Stripe Connect, cosmetic renames. (The webhook's Pages→App Router move, formerly deferred as P3.2, is folded into Phase B.) The design is forward-compatible with each.


### PR DESCRIPTION
**Phase B1** of the reservation rebuild — the inventory core, in isolation (no wiring into routes yet, so nothing in the live flow changes).

📄 Plan: `docs/plans/2026-06-checkout-reservation-rebuild.md` (Phase B) · Decision: `docs/adr/0007-reservation-based-checkout.md` · Follows #284 (schema).

> This PR also carries a plan-doc commit that aligns the spec with the final design + adds the Phase B breakdown — it was stranded on the #284 branch after that merged, so it rides along here.

## What's here
`apps/web/src/server/lib/reservations.ts` — all app code, **no stored procedures** (ADR 0007):

- **`reserve()`** — the atomic hold. Per item, one race-safe statement clamps the grant to availability and increments `reserved`:
  ```sql
  WITH locked AS (SELECT id, GREATEST("capacity"-"reserved"-"sold",0) avail
                  FROM "TicketTypes" WHERE id=$1 FOR UPDATE)
  UPDATE "TicketTypes" t SET "reserved" = t."reserved" + LEAST($2::int, locked.avail)
  FROM locked WHERE t.id = locked.id
  RETURNING LEAST($2::int, locked.avail)::int AS granted
  ```
  The `FOR UPDATE` serializes concurrent buyers of the same type → the last ticket can't be granted twice. Returns granted-per-item to drive the "we reduced your quantity" (wasAdjusted) message. Business rules (maxPurchasePerUser, sale window) stay with the caller (B2).
- **`confirm()`** — idempotent. Moves `reserved → sold` (dual-writes legacy `quantitySold` until Phase C swaps the dashboard read), materializes the Order + one `VALID` ticket per unit, marks the reservation `CONVERTED`, and enqueues the confirmation email in the outbox. A duplicate Stripe delivery (already `CONVERTED`) is a no-op returning the existing order id.
- **`release()` / `expire()`** — hand held inventory back; idempotent via a HELD-status re-check inside the transaction.

## Tests
`reservations.test.ts` (`@jest-environment node`) against a **real Postgres** (atomicity isn't mockable): concurrency (8 concurrent reserves for `capacity=1` → exactly one grant, `reserved ≤ capacity`), clamp-to-available, `confirm` idempotency (sold incremented once, one order, two VALID tickets), `release`, and `expire`.

**Running them:** point env at the dev or a preview branch, then `cd apps/web && yarn test reservations`. (This PR has no migration, so Branching won't auto-spin a preview branch; tests run against the dev branch — they self-provision a fixture event and clean up by event id.)

## Verification
- ✅ `npm run typecheck`
- ✅ jest harness wired (uses the existing `next/jest` config; suite discovered)
- ⬜ `yarn test reservations` against a reachable branch DB (needs your env)

## Next
- **B2** — wire it in: `/initiate` → `reserve()`; `/config`+`/apply-code` → `capacity−reserved−sold`; webhook → App Router + `confirm()`; cron → `expire()`.
- **B3** client (reservation-aware URLs + polling) · **B4** cutover migration + runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)