### PR TITLE
Plan: upgrade to Prisma 7 (Rust-free) instead of Drizzle

### DIFF
--- a/docs/adr/0008-drizzle-orm.md
+++ b/docs/adr/0008-drizzle-orm.md
@@ -1,13 +1,13 @@
 # 8. Drizzle as the ORM and SQL generator
 
-- **Status:** Proposed
+- **Status:** Superseded by [ADR 0012](0012-prisma-7-instead-of-drizzle.md)
 - **Date:** 2026-06-07
 
 ## Context
 
-We are building a shared `packages/db` consumed by `apps/web` (Next.js) and `apps/organizer` (Expo/React Native), and finalizing the database design in the same window. The roadmap already planned a Prisma → Drizzle migration (P4.1), deferred until *after* the schema redesign so we'd migrate onto a clean model. Building the shared package now forces the ORM choice now: building it on Prisma and re-building it on Drizzle later is wasted work.
+We are building a shared `packages/db` consumed by `apps/web` (Next.js) and `apps/organizer` (Expo/React Native), and finalizing the database design in the same window. The roadmap already planned a Prisma → Drizzle migration (P4.1), deferred until _after_ the schema redesign so we'd migrate onto a clean model. Building the shared package now forces the ORM choice now: building it on Prisma and re-building it on Drizzle later is wasted work.
 
-Prisma's runtime is a generated client + a query engine binary — awkward to share into a Metro/React Native bundle, and it keeps a codegen step in the critical path. Per [ADR 0004](0004-supabase-migrations-as-source.md), plain SQL under `supabase/migrations/` is already the source of truth and Prisma is only a *generator* (`prisma migrate diff` in `scripts/new-migration.ts`). That makes the ORM swappable: the pipeline only needs *some* tool to diff a schema model into reviewable SQL.
+Prisma's runtime is a generated client + a query engine binary — awkward to share into a Metro/React Native bundle, and it keeps a codegen step in the critical path. Per [ADR 0004](0004-supabase-migrations-as-source.md), plain SQL under `supabase/migrations/` is already the source of truth and Prisma is only a _generator_ (`prisma migrate diff` in `scripts/new-migration.ts`). That makes the ORM swappable: the pipeline only needs _some_ tool to diff a schema model into reviewable SQL.
 
 ## Decision
 

--- a/docs/adr/0010-vitest-for-packages.md
+++ b/docs/adr/0010-vitest-for-packages.md
@@ -7,7 +7,7 @@
 
 The shared packages ship raw ESM TypeScript ([ADR 0009](0009-shared-package-topology.md)). The core testability goal of the initiative is that services are pure `(db, input) => result` functions, so most new tests are package-local service tests. `apps/web` already has an entrenched Jest setup (jsdom, `@testing-library/react`) for component tests, and the B1 reservation harness (`reservations.test.ts`) uses Jest globals against a real preview Postgres.
 
-Jest needs `ts-jest`/babel and ESM workarounds to run raw-TS ESM packages; Vitest runs TS/ESM natively with near-zero config and is the de-facto runner for Drizzle/tRPC packages.
+Jest needs `ts-jest`/babel and ESM workarounds to run raw-TS ESM packages; Vitest runs TS/ESM natively with near-zero config and is the de-facto runner for modern Prisma/tRPC TypeScript packages.
 
 ## Decision
 

--- a/docs/adr/0012-prisma-7-instead-of-drizzle.md
+++ b/docs/adr/0012-prisma-7-instead-of-drizzle.md
@@ -1,0 +1,32 @@
+# 12. Prisma 7 (Rust-free client) instead of Drizzle
+
+- **Status:** Accepted
+- **Date:** 2026-06-08
+- **Supersedes:** [ADR 0008](0008-drizzle-orm.md)
+
+## Context
+
+[ADR 0008](0008-drizzle-orm.md) chose Drizzle for `packages/db`, to be consumed by `apps/web` (Next.js) and `apps/organizer` (Expo/React Native). Its headline argument was technical: _"Prisma's runtime is a generated client + query engine binary — awkward to share into a Metro/React Native bundle."_ Secondary points were the codegen step and that pure-function services over a `db` handle are easier to unit-test.
+
+Two things have changed since 0008 was written:
+
+1. **The architecture neutralizes the bundling argument.** Under [ADR 0009](0009-shared-package-topology.md), the RN app never imports the DB client. It talks to the server over **tRPC/HTTP**; the DB client lives behind the `server-only` quarantine and the Expo bundle only ever pulls **type-only** entries (`@troptix/db/types`, the `AppRouter` type). Prisma's query engine never enters Metro either way — so "Prisma can't bundle into RN" does not bite.
+
+2. **Prisma 7 removes the engine binary.** The new `prisma-client` generator is **Rust-free** (TypeScript/WASM query compiler), ESM-first, and connects through a **driver adapter** (`@prisma/adapter-pg` over a `pg` Pool). The result is a lightweight TS module over `pg` — structurally close to Drizzle in the ways that mattered for a shared package.
+
+The repo is on **Prisma 5.22**. A two-major upgrade (5 → 6 → 7) reconciles cleanly: a grep confirms **none** of the v6 breaking changes apply (no implicit m-n relations, no `Bytes`, no `NotFoundError`, no `fullTextSearch`), and the v7 changes are contained (ESM, new provider + `output`, driver adapter, `prisma.config.ts`, `migrate diff` flag renames). Adopting Drizzle instead would mean porting 40+ Prisma call sites and re-verifying the already-tested reservation primitives (`reserve`/`confirm`/`release`/`expire`, #285).
+
+## Decision
+
+**Upgrade to Prisma 7 (Rust-free `prisma-client` generator + `@prisma/adapter-pg`) and keep Prisma as the ORM for `packages/db`.** Do not adopt Drizzle.
+
+Prisma stays a _generator_ on the [ADR 0004](0004-supabase-migrations-as-source.md) pipeline: plain SQL under `supabase/migrations/` remains the source of truth, generated via `prisma migrate diff` (its v7 flags read the datasource from `prisma.config.ts`). `apply-migration.ts` (`supabase db push`) is untouched. The generated client is emitted to a gitignored `output` dir and re-exported from `packages/db`: the server entry exports the `prisma` singleton (`server-only`), and `@troptix/db/types` re-exports model/enum **types** (erasable, RN-safe).
+
+Sequencing: **PR1** upgrades 5→7 in place in `apps/web` (validated in isolation); **PR2** relocates Prisma into `packages/db`. The schema redesign and Supabase Auth stages then proceed on Prisma 7.
+
+## Consequences
+
+- **Good:** keeps the entire working app and the tested reservation code — no ORM port. Gets the lightweight, engine-free, shareable client that motivated the move off Prisma. The migrations pipeline survives with a flag change, not a rewrite. The `reserve` race-safe conditional `UPDATE` stays as raw SQL (Prisma `$queryRaw`), exactly as it would have under Drizzle.
+- **Trade-off:** a real two-major upgrade with v7-specific surface — ESM (`"type": "module"`), the new generator `output`, the driver adapter (incl. **Supabase SSL** and **pg connection-pool** settings, which differ from v6 defaults), `prisma.config.ts`, and the `prisma migrate diff` flag renames that touch `new-migration.ts`. Prisma still has a codegen step (`prisma generate`) — the one Drizzle advantage we forgo.
+- **Risk:** Prisma 7 is relatively new (less battle-tested than Prisma 5); the pg driver adapter against Supabase's pooled connection needs verification (pgbouncer transaction mode vs prepared statements). Mitigated by upgrading in isolation (PR1) before the package move and schema redesign.
+- **Supersedes** [ADR 0008](0008-drizzle-orm.md). [ADR 0007](0007-reservation-based-checkout.md)'s Prisma assumption is reinstated — the reservation primitives are kept, not ported. [ADR 0004](0004-supabase-migrations-as-source.md), [0009](0009-shared-package-topology.md), [0010](0010-vitest-for-packages.md), [0011](0011-supabase-auth-identity.md) are unaffected.

--- a/docs/plans/2026-06-prisma-7-upgrade.md
+++ b/docs/plans/2026-06-prisma-7-upgrade.md
@@ -1,0 +1,77 @@
+---
+title: Prisma 7 Upgrade (Rust-free client) + relocation into packages/db
+status: proposed
+created: 2026-06-08
+tracking-issue: TBD
+---
+
+# Prisma 7 Upgrade + Relocation into `packages/db`
+
+Upgrade the stack from **Prisma 5.22 → 7.x**, adopt the Rust-free `prisma-client` generator + `@prisma/adapter-pg`, and land Prisma as the ORM of the shared `packages/db`. This **replaces** the Drizzle baseline that was Stage 1a of the [shared-packages platform plan](2026-06-shared-packages-platform.md). Backing decision: [ADR 0012](../adr/0012-prisma-7-instead-of-drizzle.md) (supersedes [ADR 0008](../adr/0008-drizzle-orm.md)). Pipeline unchanged in spirit: plain SQL stays the source of truth ([ADR 0004](../adr/0004-supabase-migrations-as-source.md)); Prisma is the generator.
+
+## Why
+
+The reason ADR 0008 left Prisma — _"the query-engine binary is awkward to share into a Metro/RN bundle"_ — is moot under [ADR 0009](../adr/0009-shared-package-topology.md): the RN app consumes the server over **tRPC/HTTP** and only ever imports **type-only** entries, so Prisma runtime never enters Metro. Prisma 7's Rust-free client closes the remaining gap (engine-free, ESM, `pg` driver adapter). Net: get the light, shareable client **without** porting 40+ call sites or re-verifying the tested reservation primitives (#285).
+
+## Breaking-change reconciliation (verified in-repo)
+
+**v5 → v6 — no applicable changes.** Grep confirms: no implicit m-n relations (every `Model[]` is the parent side of an explicit 1-many FK, so the index→primary-key change doesn't fire), no `Bytes` fields, no `NotFoundError` usage, no `fullTextSearch`, no reserved model names. v6 is a version bump.
+
+**v6 → v7 — the actual work:**
+
+| Change                                               | Action                                                                                                                                                                                                           |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ESM-only                                             | `packages/db` becomes `"type": "module"`; tsconfig already `module: ESNext` / `moduleResolution: bundler`. Next transpiles `@troptix/db`.                                                                        |
+| New `prisma-client` provider + **required `output`** | Generated client leaves `node_modules`; emit to a gitignored dir; re-export behind one barrel so call sites don't scatter. `@prisma/client` import path changes.                                                 |
+| **Driver adapter mandatory**                         | `@prisma/adapter-pg` + `pg` in `server/prisma.ts`. **+ Supabase SSL** (`ssl: { rejectUnauthorized: false }` to match v6, or proper CA) and **pool settings** (pg has no default connection timeout; v6 used 5s). |
+| `prisma.config.ts`                                   | New home for schema path + datasource URL (the `datasource` `url`/`directUrl` are deprecated). Uses `dotenv`.                                                                                                    |
+| **`migrate diff` flag renames**                      | Breaks `new-migration.ts`: `--from-url` / `--from-empty` → `--from-config-datasource`; verify `--to-schema-datamodel` → `--to-schema`. The connection moves into `prisma.config.ts`.                             |
+| Env not auto-loaded                                  | Scripts already use `tsx --env-file`; `prisma.config.ts` adds `import 'dotenv/config'`.                                                                                                                          |
+| `migrate dev`/`db push` no longer auto-`generate`    | N/A — pipeline is custom diff + `supabase db push`; `postinstall: prisma generate` stays explicit.                                                                                                               |
+
+Untouched: `apply-migration.ts` (uses `supabase db push`, not `migrate diff`). No `$use`/`$metrics`/middleware in the codebase. `server/prisma.ts` is already a singleton — only **3 stray `new PrismaClient()`** to fold in.
+
+## Phases (one PR each)
+
+### PR 1 — Prisma 5 → 7, in place in `apps/web`
+
+Validate the two-major upgrade where everything already lives, before any package move.
+
+- Bump `prisma` + `@prisma/client` → `^7`; add `@prisma/adapter-pg` + `pg` (+ `@types/pg`).
+- `schema.prisma`: generator → `provider = "prisma-client"`, `output = "../src/generated/prisma"` (gitignored).
+- Add root `prisma.config.ts` (schema path; `datasource.url = env(POSTGRES_URL_NON_POOLING)` for CLI/migrations; `dotenv`).
+- Rework `server/prisma.ts`: `new PrismaClient({ adapter: new PrismaPg({ connectionString, ssl }) })`, dev-global singleton, pool config. Re-export the generated `Prisma` namespace/types from this barrel.
+- Delete the 3 stray `new PrismaClient()`; point them at the singleton.
+- Update `@prisma/client` imports → the barrel / generated path.
+- Fix `new-migration.ts` for v7 `migrate diff` (config-datasource flags); keep the Supabase timestamp-filename + "review then `yarn db:apply`" contract.
+- **Gate:** `prisma generate` clean; `npm run typecheck` green; a no-op `yarn db:new` diff produces empty SQL (proves the pipeline + a real DB connection through the adapter).
+
+### PR 2 — Relocate Prisma into `packages/db`
+
+- Move `schema.prisma` + `prisma.config.ts` + generated output into `packages/db`; `"type": "module"`; `postinstall: prisma generate`.
+- `packages/db/src/index.ts` (server entry, `server-only`) exports the `prisma` singleton + `DB`/`Tx` handle types; `packages/db/src/types.ts` re-exports model/enum **types** (RN-safe, erasable) — replacing the Stage-0 placeholders.
+- Keep `apps/web/src/server/prisma.ts` as a thin re-export of `@troptix/db` so call sites don't churn a second time (migrate them to `@troptix/db` opportunistically / in Stage 2).
+- Re-point the migration scripts at `packages/db`'s schema/config. Pipeline contract unchanged.
+- **Gate:** typecheck green across `web` + `@troptix/db`; `@troptix/db/types` stays runtime-free (the RN-safety invariant).
+
+### Then
+
+- **Schema redesign migrations** (was Stage 1b) — on Prisma 7.
+- **Supabase Auth** (Stage 1c) — unchanged by this ADR.
+
+## Verification
+
+- **Per PR:** `prisma generate` + `npm run typecheck`; `yarn db:new <noop>` emits empty SQL against a preview/dev branch (datasource via `prisma.config.ts` through the pg adapter).
+- **Adapter/Supabase:** confirm the `pg` adapter connects to the Supabase connection (SSL + pooled-vs-direct: use the direct / session-pooler URL; watch pgbouncer transaction-mode + prepared statements). Configure a connection timeout to match v6.
+- **Runtime smoke:** an existing read path (e.g. event/dashboard query) returns identical results pre/post upgrade.
+
+## Risks
+
+- **Prisma 7 newness** vs Prisma 5 maturity → upgrade isolated in PR1 with a runtime smoke check before the package move.
+- **pg adapter ↔ Supabase pooler** (pgbouncer) → verify connection mode; prefer direct/session pooler for the adapter; set pool timeout.
+- **SSL default change** (node-pg vs Rust engine) → `rejectUnauthorized: false` initially, proper CA later.
+- **`migrate diff` flag drift** → confirm exact v7 flag names against the CLI reference; gate on an empty no-op diff.
+
+## Out of scope
+
+Drizzle (dropped — ADR 0012). The schema redesign and Supabase Auth (their own stages). Stripe Connect; turbo; the RN app (being rebuilt separately).

--- a/docs/plans/2026-06-shared-packages-platform.md
+++ b/docs/plans/2026-06-shared-packages-platform.md
@@ -1,34 +1,35 @@
 ---
-title: Shared DB+API Packages, Drizzle, Supabase Auth & Checkout Service Extraction
+title: Shared DB+API Packages, Prisma 7, Supabase Auth & Checkout Service Extraction
 status: proposed
 created: 2026-06-07
 tracking-issue: TBD
 ---
 
-# Platform Redesign: Shared Packages, Drizzle, Supabase Auth, tRPC
+# Platform Redesign: Shared Packages, Prisma 7, Supabase Auth, tRPC
 
 ## Context
 
-TropTix is between live events — **no traffic right now**. That is a rare safe window to do the invasive structural work that the existing docs deliberately deferred *because the system was live*. The goal of this initiative: simplify the checkout backend, finalize the database design, and extract a **shared, typed data-access + API layer** so every client (web, the Expo organizer app, future clients) consumes one source of truth instead of hand-mirroring types.
+TropTix is between live events — **no traffic right now**. That is a rare safe window to do the invasive structural work that the existing docs deliberately deferred _because the system was live_. The goal of this initiative: simplify the checkout backend, finalize the database design, and extract a **shared, typed data-access + API layer** so every client (web, the Expo organizer app, future clients) consumes one source of truth instead of hand-mirroring types.
 
-This builds directly on work already merged: the shared Stripe client (#279), the reservation schema foundation (#284, Phase A), and the `reserve`/`confirm`/`release`/`expire` primitives + tests (#285, B1). Per #286, the checkout *cutover* (B2–B4) was folded into an imminent checkout redesign — this plan **is** that redesign, plus the platform foundation it sits on. Backing decisions: [ADR 0008](../adr/0008-drizzle-orm.md), [ADR 0009](../adr/0009-shared-package-topology.md), [ADR 0010](../adr/0010-vitest-for-packages.md), [ADR 0011](../adr/0011-supabase-auth-identity.md). Schema changes ship through the Supabase migrations pipeline ([ADR 0004](../adr/0004-supabase-migrations-as-source.md)).
+This builds directly on work already merged: the shared Stripe client (#279), the reservation schema foundation (#284, Phase A), and the `reserve`/`confirm`/`release`/`expire` primitives + tests (#285, B1). Per #286, the checkout _cutover_ (B2–B4) was folded into an imminent checkout redesign — this plan **is** that redesign, plus the platform foundation it sits on. Backing decisions: [ADR 0012](../adr/0012-prisma-7-instead-of-drizzle.md) (Prisma 7, supersedes the Drizzle ADR 0008), [ADR 0009](../adr/0009-shared-package-topology.md), [ADR 0010](../adr/0010-vitest-for-packages.md), [ADR 0011](../adr/0011-supabase-auth-identity.md). Schema changes ship through the Supabase migrations pipeline ([ADR 0004](../adr/0004-supabase-migrations-as-source.md)).
 
 **Problems being solved (all verified in-repo):**
+
 - **Type duplication** — `apps/web/src/types/checkout.ts` and `apps/organizer/hooks/types/Ticket.ts` hand-mirror each other and Prisma enums. No shared package.
 - **No service layer** — Prisma is imported directly in 40+ files; `initiate/route.ts` is a 609-line monolith; logic is bound to HTTP routes and hard to unit-test.
 - **Dual-era schema** — legacy columns (`quantity`/`quantitySold`, Float prices, split `startDate`/`startTime`, `AVAILABLE`/`NOT_AVAILABLE`) coexist with the additive Phase-A columns; renames/drops were deferred.
-- **Auth identity is foreign** — `User.id` *is* the Firebase UID (`api/user/create/route.ts` does `users.create({ data: { id }})`), propagated as a FK everywhere. RLS is enabled (#283) but inert because the DB session has no `auth.uid()`.
+- **Auth identity is foreign** — `User.id` _is_ the Firebase UID (`api/user/create/route.ts` does `users.create({ data: { id }})`), propagated as a FK everywhere. RLS is enabled (#283) but inert because the DB session has no `auth.uid()`.
 - **Monorepo isn't wired** — root `package.json` `workspaces` lists only `apps/web` (+ a phantom `apps/server`); `apps/organizer`, `apps/backstage`, and `packages/*` are outside the graph.
 
 ## Locked decisions (the stack)
 
-| Fork | Decision |
-|---|---|
-| **API layer** | Framework-agnostic **service layer** (`packages/api/services`, pure `(db, input) => result` fns) + a **thin tRPC adapter**. Stripe webhook + cron stay plain REST and call the *same* services. |
-| **ORM** | **Drizzle** in `packages/db`. Drizzle replaces Prisma as the schema source + SQL generator on the existing ADR-0004 pipeline (plain SQL stays source of truth). |
-| **DB scope** | **Full Priority-2 redesign now** — semantic changes *and* the rename/drop sweep. |
-| **Auth** | **Firebase → Supabase Auth**, folded into the foundation stage. **Preserve accounts** (and Orders/Tickets — financial/attendance records). Identity: keep existing `User.id` **stable**, add `authUserId uuid @unique → auth.users(id)`; RLS keys off `auth.uid() = authUserId`. |
-| **Sequencing** | Cutover folded into the checkout redesign (#286): B2 server wiring + new client ship as one atomic maintenance-window PR. |
+| Fork           | Decision                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **API layer**  | Framework-agnostic **service layer** (`packages/api/services`, pure `(db, input) => result` fns) + a **thin tRPC adapter**. Stripe webhook + cron stay plain REST and call the _same_ services.                                                                                                                                                                                                                                                                                                                                                  |
+| **ORM**        | ~~Drizzle~~ → **Prisma 7** (Rust-free `prisma-client` + `@prisma/adapter-pg`) in `packages/db`, on the existing ADR-0004 pipeline (plain SQL stays source of truth). Reversed per [ADR 0012](../adr/0012-prisma-7-instead-of-drizzle.md) (supersedes 0008): under the tRPC + `server-only` topology the RN app never bundles the DB client, so Prisma's engine was never the blocker — and Prisma 7 is engine-free. Avoids porting 40+ call sites + the tested reservation primitives. See [Prisma 7 upgrade plan](2026-06-prisma-7-upgrade.md). |
+| **DB scope**   | **Full Priority-2 redesign now** — semantic changes _and_ the rename/drop sweep.                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| **Auth**       | **Firebase → Supabase Auth**, folded into the foundation stage. **Preserve accounts** (and Orders/Tickets — financial/attendance records). Identity: keep existing `User.id` **stable**, add `authUserId uuid @unique → auth.users(id)`; RLS keys off `auth.uid() = authUserId`.                                                                                                                                                                                                                                                                 |
+| **Sequencing** | Cutover folded into the checkout redesign (#286): B2 server wiring + new client ship as one atomic maintenance-window PR.                                                                                                                                                                                                                                                                                                                                                                                                                        |
 
 **Assumption stated:** all data is preserved (Users, Events, Orders, Tickets). Migrations are written as real backfills with verification gates, not truncate-and-rebuild.
 
@@ -45,7 +46,7 @@ packages/db  ◄── packages/api/services  ◄── packages/api/trpc (route
    apps/organizer (Expo) ──────── tRPC react-query ──┘
 ```
 
-**Two-entry packages = the RN-safety mechanism.** Server runtime (Drizzle client, `pg`, the router *value*) is quarantined behind `server-only` entries the Expo bundle never imports; clients import **`import type { AppRouter }`** (erased by Babel) + zod contract types only.
+**Two-entry packages = the RN-safety mechanism.** Server runtime (the Prisma 7 client, `pg`, the router _value_) is quarantined behind `server-only` entries the Expo bundle never imports; clients import **`import type { AppRouter }`** (erased by Babel) + zod contract types only.
 
 - `@troptix/db` → server (has `import 'server-only'`); `@troptix/db/types` → inferred row/enum types, zero runtime imports (RN-safe).
 - `@troptix/api` → type-only barrel (`AppRouter` type + zod contracts); `@troptix/api/server` → `appRouter`, `createContext`, `createCaller`, services (server-only).
@@ -56,7 +57,8 @@ packages/db  ◄── packages/api/services  ◄── packages/api/trpc (route
 
 The data spine is inherently sequential (types flow downward); parallel seams are marked **∥**. Design-system / Priority-5 work runs alongside throughout.
 
-### Stage 0 — Monorepo wiring *(small, unblocks everything)*
+### Stage 0 — Monorepo wiring _(small, unblocks everything)_
+
 - Root `package.json` `workspaces` → `["apps/*", "packages/*"]`. Ensure the two empty `packages/troptix-*` have valid `package.json` or delete them.
 - Add `tsconfig.base.json` with path aliases (`@troptix/db`, `@troptix/api`); each app/package `extends` it.
 - **Ship TS source, no build step** — `main`/`types` point at `.ts`; consumers transpile (Next `transpilePackages` — `externalDir: true` already set; Expo/Metro via `watchFolders`).
@@ -65,16 +67,17 @@ The data spine is inherently sequential (types flow downward); parallel seams ar
 - **Metro config** (`apps/organizer/metro.config.js`): `watchFolders = [workspaceRoot]`, `nodeModulesPaths` app→root, `unstable_enableSymlinks`.
 
 ### Stage 1 — Foundation: `packages/db` + schema redesign + Supabase Auth
+
 Mostly sequential (migration ordering is load-bearing). Each migration = its own PR on a Supabase preview branch.
 
-**1a. Drizzle baseline (re-baseline, don't introspect)**
-- `packages/db/src/{schema,relations,enums,client,types}.ts`, `drizzle.config.ts` with `out: ../../supabase/migrations`.
-- Author `schema.ts` to model the **current dual-era reality** (matches today's `schema.prisma`), then `drizzle-kit generate --custom` to write the **meta snapshot only** (tables already exist on every branch).
-- **Empty-diff gate:** recreate a preview branch from the 3 existing SQL migrations; confirm `drizzle-kit generate` emits an empty diff. Non-empty ⇒ snapshot drifted from the hand-written SQL; fix `schema.ts` until empty. This preserves ADR-0004's "dev is derived-from-migrations" invariant.
-- Replace the body of `apps/web/scripts/new-migration.ts` (`prisma migrate diff` → `drizzle-kit generate`), keeping the Supabase timestamp filename + "review then `yarn db:apply`" contract. `apply-migration.ts` (`supabase db push`) is unchanged. Prisma client stays live this stage (dual-ORM) until services port in Stage 2.
-- `client.ts`: Drizzle over a `pg` Pool, same dev-global singleton pattern as `apps/web/src/server/prisma.ts`; reuse existing Supabase connection env vars. Export `DB`/`Tx` handle types; services type against `DB | Tx`.
+**1a. Prisma 7 upgrade + relocation into `packages/db`** _(replaces the former Drizzle baseline — [ADR 0012](../adr/0012-prisma-7-instead-of-drizzle.md))_
+
+- Upgrade Prisma **5.22 → 7** (Rust-free `prisma-client` generator + `@prisma/adapter-pg`); then move the schema + generated client into `packages/db`. Full breakdown + the two PRs (upgrade-in-place → relocate) in the [Prisma 7 upgrade plan](2026-06-prisma-7-upgrade.md).
+- `packages/db/src/{index,types}.ts`: server entry exports the `prisma` singleton (`server-only`) + `DB`/`Tx` handle types; `./types` re-exports model/enum types (RN-safe). `prisma.config.ts` holds the datasource (ADR-0004 pipeline kept; `prisma migrate diff` flags updated for v7).
+- `new-migration.ts` keeps the Supabase timestamp filename + "review then `yarn db:apply`" contract; `apply-migration.ts` (`supabase db push`) is unchanged. No dual-ORM — Prisma is the single ORM throughout.
 
 **1b. Schema redesign migrations — order: backfill → constrain → drop → rename**
+
 - **M4 backfill (data-only):** `Events.startsAt/endsAt` ← `startDate+startTime` (fixes the sale-window-ignores-time bug); `TicketTypes`: `saleStartsAt/saleEndsAt`, `capacity ← quantity`, `sold ← quantitySold`, `priceCents ← round(price*100)`; `Orders.*Cents`, `Orders.type`; `Tickets` status `AVAILABLE→VALID` / `NOT_AVAILABLE→CANCELLED`. **Verification queries must return 0 nulls before proceeding.**
 - **M5 NOT NULL** on backfilled columns. **M6 CHECK** constraints: `reserved>=0 AND sold>=0 AND reserved+sold<=capacity` (the invariant `reserve` relies on), cents `>=0`.
 - **M7 drop dead tables:** `Promotions`, `DelegatedUsers`, `SocialMediaAccounts` (+ enums). Grep-confirm no code refs first (`SocialMediaAccounts` is in the Users relation — remove it).
@@ -85,8 +88,9 @@ Mostly sequential (migration ordering is load-bearing). Each migration = its own
 - **M12 mandatory timestamps** NOT NULL + defaults everywhere.
 
 **1c. Supabase Auth migration (account-preserving, orphan-safe order)**
+
 1. **Add column** `User.authUserId uuid UNIQUE REFERENCES auth.users(id) ON DELETE SET NULL` (nullable initially; slot before the rename sweep on `Users`).
-2. **Import Firebase users → `auth.users`** (one-time script per env via Supabase Admin API, *not* a SQL migration): export via Firebase Admin `listUsers()`; import **preserving passwords** using GoTrue's `firebase_scrypt` algorithm + project signer key/salt/rounds/mem params (test a handful first — wrong params = silent login failure). Capture the `firebaseUid → new authUserId` map. **Stamp `app_metadata.troptix_user_id = User.id`** so the stable id rides in the JWT.
+2. **Import Firebase users → `auth.users`** (one-time script per env via Supabase Admin API, _not_ a SQL migration): export via Firebase Admin `listUsers()`; import **preserving passwords** using GoTrue's `firebase_scrypt` algorithm + project signer key/salt/rounds/mem params (test a handful first — wrong params = silent login failure). Capture the `firebaseUid → new authUserId` map. **Stamp `app_metadata.troptix_user_id = User.id`** so the stable id rides in the JWT.
 3. **Backfill** `User.authUserId` from the map. **Orphan gate:** `SELECT count(*) FROM "Users" WHERE "authUserId" IS NULL` must be 0 before any auth code flips.
 4. **RLS policies** (hand-appended per #281, on final table names) keyed off `auth.uid() = authUserId` (join through stable `userId` for `Order`/`OrderTicket`/`Reservation`; through `Event.organizerUserId` for organizer-scoped tables). **App stays on the bypassrls connection this stage** — policies validated on preview branches but not yet load-bearing (going live is a later runtime change).
 5. **Cut over verification** in `apps/web/src/server/authUser.ts` + `src/server/lib/auth.ts`: replace `firebase-admin verifyIdToken` with Supabase JWT verification; return shape stays `{ userId, email }` where `userId` = `app_metadata.troptix_user_id` (the stable `User.id`) so the 24 callsites are untouched. Switch cookie `fb-token` → Supabase session cookies (`@supabase/ssr`).
@@ -94,12 +98,14 @@ Mostly sequential (migration ordering is load-bearing). Each migration = its own
 7. **Dual-verify shim** in `authUser.ts` (try Supabase, fall back to Firebase) covers the **Expo cross-repo lag** until the organizer app ships Supabase tokens; remove shim + uninstall `firebase`/`firebase-admin` after.
 
 ### Stage 2 — `packages/api`: services + contracts + tRPC
+
 - **`contracts/` (zod)** — port `apps/web/src/types/checkout.ts` (`ValidationResponse`, `CheckoutTicket`, `ApplyCodeResponse`, message enums) to zod schemas; one definition consumed by services (`.parse`), tRPC (`.input()`), and clients (`z.infer`). **This is the contract-freeze point that unlocks Stage 3 ∥ work.**
-- **`services/`** — port `apps/web/src/server/lib/reservations.ts` near-mechanically (Prisma `$transaction` → `db.transaction`; race-safe `reserve` CTE stays raw SQL via Drizzle's `sql` tag against `"EventTicket"`; functions take `db` as first arg). Port `getCheckoutConfig` (from `config/route.ts`), `applyCode`, `events`, `organizer` reads, `_shared/fees`.
+- **`services/`** — move `apps/web/src/server/lib/reservations.ts` near-as-is (it's already Prisma `$transaction`; the race-safe `reserve` conditional `UPDATE` stays raw SQL via `$queryRaw`); refactor each fn to take the `prisma`/`tx` handle as its first arg so services are injectable/unit-testable. Port `getCheckoutConfig` (from `config/route.ts`), `applyCode`, `events`, `organizer` reads, `_shared/fees`. (Keeping Prisma per ADR 0012 makes this a move + signature change, not an ORM rewrite.)
 - **`trpc/`** — `initTRPC`, `publicProcedure`/`protectedProcedure` (auth middleware over `ctx.session`); `context.ts` builds `{ db, session }` from the request (Supabase JWT, Bearer for RN); `routers/{checkout,events,organizer}.ts` are thin pass-throughs. `confirm`/`expire` are **not** procedures — webhook/cron drive them.
 - **Webhook + cron rewrite** — `src/pages/api/stripe/webhook.ts` stays REST (needs raw body for signature verify), rewritten to call `confirm(db, …)`; `cron/invalidate-orders` calls `expire(db, now)`. Supersedes `orderHelper`/`updateOrderAfterPaymentSucceeds`.
 
-### Stage 3 — Clients *(∥ once contracts frozen)*
+### Stage 3 — Clients _(∥ once contracts frozen)_
+
 - **3a. Web checkout redesign** (first consumer; atomic cutover PR per #286): new reservation-aware checkout pages on `trpc.checkout.*` via `@trpc/react-query`; `/api/trpc/[trpc]/route.ts` App Router handler; server components call services directly or via `createCaller`. Replaces `useCheckout`/`useFetchCheckoutConfig`/`useApplyCode` and the old `CheckoutContainer`/`payment-form`.
 - **3b. Organizer rewire** ∥: add `@trpc/client` + `@trpc/react-query`, drop axios; `lib/trpc.ts` with `import type { AppRouter }`; hooks → `trpc.events.*` / `trpc.organizer.*` with the Supabase token via the client `headers` callback. **Delete `apps/organizer/hooks/types/Ticket.ts`** (enums now from `@troptix/db/types`).
 - **Delete** `apps/web/src/types/checkout.ts` (moved to `packages/api/contracts`).
@@ -107,12 +113,14 @@ Mostly sequential (migration ordering is load-bearing). Each migration = its own
 ---
 
 ## Testing strategy ("simple & testable")
+
 - **Pure service unit tests** (Vitest, package-local) — inject a fake `db`; no HTTP/Next/tRPC harness. Covers `getCheckoutConfig` mapping/sorting, `applyCode` gating, fee calc, response shaping.
 - **Reservation integration tests** — port the B1 `reservations.test.ts` (the 8-way concurrent "last ticket granted once" test) to `packages/api/services/reservations.test.ts` against a Supabase **preview-branch** Postgres (concurrency/locking can't be mocked).
 - **Runner:** Vitest for `packages/*` (native ESM/TS, the tests you write most); Jest stays for `apps/web` components. Root `yarn test` fans out via `workspaces foreach`. Rewrite `jest.config.ts` `projects` (drop phantom `server`). See [ADR 0010](../adr/0010-vitest-for-packages.md).
 - **Lint guardrail:** ESLint `no-restricted-imports` banning `@troptix/api/server` + `@troptix/db` from `apps/organizer`.
 
 ## Verification (end-to-end)
+
 - **Per migration PR:** Supabase Branching preview DB; after apply, `yarn db:new` emits **no diff** (snapshot ↔ DB consistent); backfill verification queries return 0 nulls.
 - **Rename gate:** `prisma generate` + `yarn typecheck` green across all import sites after M11.
 - **Auth:** import test users to a preview DB, verify password-preserving sign-in (web + a simulated Supabase Bearer token for RN), verify an organizer read still resolves by stable `User.id`; orphan-gate null-count = 0.
@@ -120,7 +128,8 @@ Mostly sequential (migration ordering is load-bearing). Each migration = its own
 - Keep the Firebase project read-available until the dual-verify shim is removed (rollback).
 
 ## Risks
-- **Drizzle baseline drift** → empty-diff gate against a fresh-from-migrations branch.
+
+- **Prisma 7 upgrade surface** (ESM, new `prisma-client` generator + `output`, `pg` driver adapter, Supabase SSL/pool, `migrate diff` flag renames) → upgrade isolated in its own PR with a runtime smoke check before the package move; see the [Prisma 7 upgrade plan](2026-06-prisma-7-upgrade.md).
 - **Enum drop (M9)** hard-fails if any row holds a dead value → backfill + pre-flight count gate; isolate the migration.
 - **Password import fidelity** → test a handful before bulk; wrong scrypt params fail silently.
 - **`authUserId` vs stable `id` confusion** across 24 auth callsites → stamp `troptix_user_id` in JWT; assert return shape in a test.
@@ -129,9 +138,11 @@ Mostly sequential (migration ordering is load-bearing). Each migration = its own
 - **Workspace re-hoist** React/RN skew → `nohoist` Expo toolchain; single hoisted TS version via `resolutions`.
 
 ## Out of scope
-- Going *live* on RLS (app stays bypassrls; flipping the runtime connection to `authenticated` is a later hardening step once policies are proven).
+
+- Going _live_ on RLS (app stays bypassrls; flipping the runtime connection to `authenticated` is a later hardening step once policies are proven).
 - Full transactional email service (minimal outbox only, already present).
 - Stripe Connect; `apps/backstage` build-out; turbo adoption.
 
 ## Execution
+
 Implementation PRs reference the umbrella tracking issue (TBD) and the stage above. The four backing ADRs (0008–0011) ship with this plan for review; they move to **Accepted** when this plan is approved and flipped to `active`.


### PR DESCRIPTION
**Plan PR — review the decision, not an implementation.** No app code changes here; docs only.

Reverses the Drizzle decision ([ADR 0008](docs/adr/0008-drizzle-orm.md)) in favour of upgrading to **Prisma 7** (Rust-free `prisma-client` generator + `@prisma/adapter-pg`).

## Why
Under the tRPC + `server-only` topology ([ADR 0009](docs/adr/0009-shared-package-topology.md)), the RN app talks to the server over HTTP and only imports **type-only** entries — so Prisma's engine was never going to enter the Metro bundle. That was ADR 0008's headline argument for Drizzle, and it doesn't hold. Prisma 7 is engine-free anyway, so we get the light, shareable client **without** porting 40+ call sites or re-verifying the tested reservation primitives (#285).

## Contents
- **`docs/adr/0012-prisma-7-instead-of-drizzle.md`** (Accepted) — the decision; **0008 → Superseded**.
- **`docs/plans/2026-06-prisma-7-upgrade.md`** — breaking-change reconciliation (v5→v6 is free for us; v6→v7 is the real work: ESM, new generator + `output`, `pg` driver adapter, `prisma.config.ts`, `migrate diff` flag renames) and the two implementation PRs.
- Umbrella plan (`2026-06-shared-packages-platform.md`) + ADR 0010 reconciled.

## Implementation (follows in separate PRs)
- **PR1** — Prisma 5→7 upgrade in place in `apps/web` (validated in isolation).
- **PR2** — relocate Prisma into `packages/db`.
- Then: schema redesign migrations → Supabase Auth.

## Open verification items (called out in the plan)
- `pg` adapter ↔ Supabase pooler (direct/session-pooler + SSL + pool timeout).
- Exact v7 `migrate diff` flag names vs the live CLI before rewriting `new-migration.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)