### PR TITLE
Stage 2 PR 2b: zod contracts + checkout read services

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "@troptix/db": "0.0.0",
-    "short-unique-id": "^5.0.3"
+    "short-unique-id": "^5.0.3",
+    "zod": "^3.24.3"
   },
   "devDependencies": {
     "dotenv": "^17.2.0",

--- a/packages/api/src/contracts/checkout.ts
+++ b/packages/api/src/contracts/checkout.ts
@@ -1,0 +1,166 @@
+/**
+ * Checkout contracts — the single zod definition of the checkout wire shape.
+ *
+ * One schema serves three roles (ADR 0009): services `.parse()` inputs at the
+ * trust boundary, the tRPC adapter uses them as `.input`/output, and clients
+ * derive types via `z.infer`. This is the **contract-freeze point** the Stage 2
+ * plan calls out — the Stage 3 checkout redesign builds against these shapes.
+ *
+ * RN-safe: this module imports zod + `@troptix/db/types` (type-only) ONLY. It
+ * must never import the `@troptix/db` runtime entry, so it can live in the
+ * type-only barrel a React-Native client may import.
+ *
+ * Money is integer **cents** everywhere (roadmap 2.12) — matching the
+ * reservation service (`unitPriceCents`/`feesCents`) and the new `priceCents`
+ * column. The legacy dollar-`Float` `apps/web/src/types/checkout.ts` is retained
+ * unchanged for the un-wired legacy routes until the Stage 3 cutover retires it.
+ */
+import { z } from 'zod';
+import type { TicketFeeStructure, TicketType } from '@troptix/db/types';
+
+// --- Prisma enums mirrored as zod string enums --------------------------------
+// We can't import the enum *values* from `@troptix/db` (runtime entry) without
+// breaking RN-safety, and `@troptix/db/types` is type-only. So the values are
+// re-declared here; the parity guards below fail to compile if they ever drift
+// from the Prisma definitions.
+
+export const feeStructureSchema = z.enum([
+  'ABSORB_TICKET_FEES',
+  'PASS_TICKET_FEES',
+]);
+
+export const ticketTypeSchema = z.enum(['FREE', 'PAID', 'COMPLEMENTARY']);
+
+type AssertEqual<A, B> = [A] extends [B]
+  ? [B] extends [A]
+    ? true
+    : never
+  : never;
+
+// Resolve to `never` (so the `= true` assignment fails to compile) if the zod
+// enum ever diverges from the Prisma enum it mirrors.
+const _feeStructureParity: AssertEqual<
+  z.infer<typeof feeStructureSchema>,
+  TicketFeeStructure
+> = true;
+const _ticketTypeParity: AssertEqual<
+  z.infer<typeof ticketTypeSchema>,
+  TicketType
+> = true;
+
+// --- Validation / message enums (ported from types/checkout.ts) ---------------
+
+export const validationResponseMessageSchema = z.enum([
+  'Some tickets were unavailable or sold out and cart was adjusted',
+  'Tickets are available',
+  'All tickets are unavailable',
+  'No tickets selected',
+  'Missing required fields or no tickets selected',
+]);
+export type ValidationResponseMessage = z.infer<
+  typeof validationResponseMessageSchema
+>;
+
+export const validatedItemMessageSchema = z.enum([
+  'Available',
+  'Quantity Reduced: Max Available',
+  'Sold Out',
+  'Sale Not Started',
+  'Sale Ended',
+  'Ticket Type Not Found',
+]);
+export type ValidatedItemMessage = z.infer<typeof validatedItemMessageSchema>;
+
+// --- CheckoutTicket -----------------------------------------------------------
+
+export const checkoutTicketSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  /** Integer cents (← `priceCents`). */
+  priceCents: z.number().int(),
+  /** ISO-8601 string of the single-DateTime sale window start (← `saleStartsAt`). */
+  saleStartsAt: z.string().datetime(),
+  saleEndsAt: z.string().datetime(),
+  /** Quantity the buyer may add now — clamped to availability, max-per-user, sale window, draft state. */
+  maxAllowedToAdd: z.number().int(),
+  /** Per-ticket fee in integer cents (0 when the organizer absorbs fees). */
+  feesCents: z.number().int(),
+  feeStructure: feeStructureSchema,
+  ticketType: ticketTypeSchema.nullable(),
+  /** True when 0 < availability < 10 — drives the "almost gone" UI hint. */
+  ticketQuantityLow: z.boolean(),
+  /** Present only on a ticket unlocked via a discount/password code. */
+  isPasswordProtected: z.boolean().optional(),
+});
+export type CheckoutTicket = z.infer<typeof checkoutTicketSchema>;
+
+export const checkoutConfigResponseSchema = z.object({
+  tickets: z.array(checkoutTicketSchema),
+  message: z.string().optional(),
+});
+export type CheckoutConfigResponse = z.infer<
+  typeof checkoutConfigResponseSchema
+>;
+
+// --- applyCode ----------------------------------------------------------------
+
+export const applyCodeInputSchema = z.object({
+  eventId: z.string().min(1),
+  code: z.string().min(1),
+});
+export type ApplyCodeInput = z.infer<typeof applyCodeInputSchema>;
+
+export const applyCodeResponseSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('password'),
+    isValid: z.literal(true),
+    message: z.string(),
+    unlockedTicket: checkoutTicketSchema,
+  }),
+  z.object({
+    type: z.literal('invalid'),
+    isValid: z.literal(false),
+    message: z.string(),
+  }),
+]);
+export type ApplyCodeResponse = z.infer<typeof applyCodeResponseSchema>;
+
+// --- getCheckoutConfig input --------------------------------------------------
+
+export const checkoutConfigInputSchema = z.object({
+  eventId: z.string().min(1),
+});
+export type CheckoutConfigInput = z.infer<typeof checkoutConfigInputSchema>;
+
+// --- Validation (initiate path) ----------------------------------------------
+// Frozen here so the Stage 3 initiate rewrite (PR 2c) has the target shape;
+// the service is built in a later PR. Cents + reservation-id, not the legacy
+// dollar/orderId shape.
+
+export const validatedItemSchema = z.object({
+  ticketTypeId: z.string(),
+  name: z.string(),
+  requestedQuantity: z.number().int(),
+  validatedQuantity: z.number().int(),
+  pricePerTicketCents: z.number().int(),
+  feesPerTicketCents: z.number().int(),
+  message: validatedItemMessageSchema,
+});
+export type ValidatedItem = z.infer<typeof validatedItemSchema>;
+
+export const validationResponseSchema = z.object({
+  isValid: z.boolean(),
+  wasAdjusted: z.boolean(),
+  validatedItems: z.array(validatedItemSchema),
+  subtotalCents: z.number().int(),
+  feesCents: z.number().int(),
+  totalCents: z.number().int(),
+  promotionApplied: z.string().nullable(),
+  message: validationResponseMessageSchema.nullable(),
+  isFree: z.boolean(),
+  reservationId: z.string().nullable(),
+  clientSecret: z.string().nullable(),
+  expiresAt: z.string().datetime().nullable(),
+});
+export type ValidationResponse = z.infer<typeof validationResponseSchema>;

--- a/packages/api/src/contracts/index.ts
+++ b/packages/api/src/contracts/index.ts
@@ -1,0 +1,4 @@
+// @troptix/api contracts barrel — the zod wire schemas + inferred types.
+// RN-safe (zod + type-only @troptix/db). Re-exported from the package's
+// type-only default entry (src/index.ts).
+export * from './checkout';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -5,8 +5,7 @@
 // contract schemas/types. It must never re-export the router value, the
 // service layer, or anything that transitively imports @troptix/db.
 //
-// Stage 2 (see docs/plans/2026-06-shared-packages-platform.md) adds the zod
-// contracts and `export type { AppRouter }`. Placeholder for Stage 0 wiring.
-export type PlaceholderContract = {
-  readonly __placeholder: true;
-};
+// Stage 2 adds the zod contracts here (done) and, later, `export type
+// { AppRouter }` (PR 2c). The contracts are RN-safe: zod + type-only
+// `@troptix/db/types`, no DB runtime.
+export * from './contracts';

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -20,3 +20,12 @@ export {
   type ConfirmInput,
   type ConfirmResult,
 } from './services/reservations';
+
+export { getCheckoutConfig, applyCode } from './services/checkout';
+export {
+  calculateFeesCents,
+  getFeeBreakdownCents,
+  FeeConfig,
+  type FeeBreakdownCents,
+} from './services/_shared/fees';
+export { NotFoundError } from './services/_shared/errors';

--- a/packages/api/src/services/_shared/errors.ts
+++ b/packages/api/src/services/_shared/errors.ts
@@ -1,0 +1,20 @@
+/**
+ * Transport-agnostic service errors. Services throw these; each adapter maps
+ * them to its own status code (the REST routes → HTTP, the tRPC adapter → a
+ * `TRPCError` in PR 2c). Keeping them here means a service never imports a
+ * transport just to signal "not found".
+ *
+ * Convention — throw vs. return: **throw** a service error when something
+ * exceptional happened (a resource the caller named by id doesn't exist, the
+ * operation can't proceed). **Return a discriminated result** instead when a
+ * "failure" is a normal, expected outcome of valid input — e.g. `applyCode`
+ * returns `{ type: 'invalid' }` for a wrong code rather than throwing.
+ */
+
+/** A referenced resource (event, ticket type, …) does not exist. → HTTP 404. */
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NotFoundError';
+  }
+}

--- a/packages/api/src/services/_shared/fees.test.ts
+++ b/packages/api/src/services/_shared/fees.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for the fee rate card. Literal expected values (not re-derived
+ * from FeeConfig), so a change to the percentage/fixed/tax — or to the rounding
+ * — has to fail here rather than silently agreeing with itself.
+ */
+import { describe, expect, it } from 'vitest';
+import { calculateFeesCents, getFeeBreakdownCents } from './fees';
+
+describe('calculateFeesCents', () => {
+  it('charges nothing for free or non-positive prices', () => {
+    expect(calculateFeesCents(0)).toBe(0);
+    expect(calculateFeesCents(-100)).toBe(0);
+  });
+
+  it('applies 8% + $0.50, then 15% tax, rounded to whole cents', () => {
+    // 5000*0.08 + 50 = 450 base; 450 + 450*0.15 = 517.5 → round → 518.
+    expect(calculateFeesCents(5000)).toBe(518);
+    // 10000*0.08 + 50 = 850 base; 850 + 127.5 = 977.5 → round → 978.
+    expect(calculateFeesCents(10000)).toBe(978);
+    // 1*0.08 + 50 = 50.08 base; 50.08 + 7.512 = 57.592 → round → 58.
+    expect(calculateFeesCents(1)).toBe(58);
+  });
+});
+
+describe('getFeeBreakdownCents', () => {
+  it('is all zeros for free tickets', () => {
+    expect(getFeeBreakdownCents(0)).toEqual({
+      baseFeeCents: 0,
+      taxCents: 0,
+      totalCents: 0,
+    });
+  });
+
+  it('rounds the base first, then taxes the rounded base', () => {
+    // base round(450) = 450; tax round(450*0.15 = 67.5) = 68; total 518.
+    expect(getFeeBreakdownCents(5000)).toEqual({
+      baseFeeCents: 450,
+      taxCents: 68,
+      totalCents: 518,
+    });
+  });
+});

--- a/packages/api/src/services/_shared/fees.ts
+++ b/packages/api/src/services/_shared/fees.ts
@@ -1,0 +1,47 @@
+/**
+ * Platform fee calculation — cents-native port of `apps/web/src/lib/fees.ts`.
+ *
+ * The service layer works in integer cents end-to-end (roadmap 2.12), so these
+ * take and return cents rather than the legacy dollar `Float`s. Same rate card
+ * (8% + $0.50, then 15% tax on the fee) as the legacy helper, so a given price
+ * yields the same fee — just expressed in cents. The legacy dollar version is
+ * retained in `apps/web` for the un-wired legacy routes until Stage 3.
+ */
+export const FeeConfig = {
+  PERCENTAGE: 0.08, // 8% base fee
+  FIXED_CENTS: 50, // $0.50 fixed fee
+  TAX_RATE: 0.15, // 15% tax on fees
+} as const;
+
+export interface FeeBreakdownCents {
+  baseFeeCents: number;
+  taxCents: number;
+  totalCents: number;
+}
+
+/**
+ * Total fee (base + tax) for a ticket price, in integer cents.
+ * Free tickets carry no fee.
+ */
+/** The unrounded base fee (percentage + fixed) in cents — the rate-card formula. */
+function rawBaseFeeCents(priceCents: number): number {
+  return priceCents * FeeConfig.PERCENTAGE + FeeConfig.FIXED_CENTS;
+}
+
+export function calculateFeesCents(priceCents: number): number {
+  if (priceCents <= 0) return 0;
+
+  const baseFee = rawBaseFeeCents(priceCents);
+  return Math.round(baseFee + baseFee * FeeConfig.TAX_RATE);
+}
+
+/** Detailed fee breakdown (base / tax / total) in integer cents, for display. */
+export function getFeeBreakdownCents(priceCents: number): FeeBreakdownCents {
+  if (priceCents <= 0) {
+    return { baseFeeCents: 0, taxCents: 0, totalCents: 0 };
+  }
+
+  const baseFeeCents = Math.round(rawBaseFeeCents(priceCents));
+  const taxCents = Math.round(baseFeeCents * FeeConfig.TAX_RATE);
+  return { baseFeeCents, taxCents, totalCents: baseFeeCents + taxCents };
+}

--- a/packages/api/src/services/checkout.test.ts
+++ b/packages/api/src/services/checkout.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Unit tests for the read-side checkout services. Unlike reservations.test.ts
+ * these need NO Postgres — the services are pure over an injected `prisma`, so
+ * we hand them a hand-rolled fake that returns canned rows and assert the
+ * mapping / sorting / gating / fee logic (ADR 0010).
+ */
+import { describe, expect, it } from 'vitest';
+import type { PrismaClient } from '@troptix/db';
+import { applyCode, getCheckoutConfig } from './checkout';
+
+// A wide-open sale window around "now" so tickets are active by default.
+const PAST = new Date(Date.now() - 86_400_000);
+const FUTURE = new Date(Date.now() + 86_400_000);
+
+type Row = {
+  id: string;
+  name: string;
+  description: string;
+  maxPurchasePerUser: number;
+  ticketingFees: 'PASS_TICKET_FEES' | 'ABSORB_TICKET_FEES';
+  ticketType: 'FREE' | 'PAID' | 'COMPLEMENTARY' | null;
+  capacity: number | null;
+  reserved: number;
+  sold: number;
+  priceCents: number | null;
+  saleStartsAt: Date | null;
+  saleEndsAt: Date | null;
+  quantity: number;
+  price: number;
+  saleStartDate: Date;
+  saleEndDate: Date;
+  event: { isDraft: boolean };
+};
+
+function row(overrides: Partial<Row> = {}): Row {
+  return {
+    id: 'tt-1',
+    name: 'General Admission',
+    description: 'GA',
+    maxPurchasePerUser: 10,
+    ticketingFees: 'PASS_TICKET_FEES',
+    ticketType: 'PAID',
+    capacity: 100,
+    reserved: 0,
+    sold: 0,
+    priceCents: 5000,
+    saleStartsAt: PAST,
+    saleEndsAt: FUTURE,
+    quantity: 100,
+    price: 50,
+    saleStartDate: PAST,
+    saleEndDate: FUTURE,
+    event: { isDraft: false },
+    ...overrides,
+  };
+}
+
+/** Minimal PrismaClient stand-in exposing only what the services touch. */
+function fakePrisma(opts: {
+  ticketTypes?: Row[];
+  matchedTicketType?: Row | null;
+  eventCount?: number;
+}): PrismaClient {
+  return {
+    ticketTypes: {
+      findMany: async () => opts.ticketTypes ?? [],
+      findFirst: async () => opts.matchedTicketType ?? null,
+    },
+    events: {
+      count: async () => opts.eventCount ?? 0,
+    },
+  } as unknown as PrismaClient;
+}
+
+/** Run getCheckoutConfig over a single ticket-type row and return the mapped ticket. */
+async function firstTicket(ticketType: Row) {
+  const { tickets } = await getCheckoutConfig(
+    fakePrisma({ ticketTypes: [ticketType] }),
+    { eventId: 'evt-1' }
+  );
+  return tickets[0];
+}
+
+describe('getCheckoutConfig', () => {
+  it('maps a ticket type to the cents contract', async () => {
+    const prisma = fakePrisma({ ticketTypes: [row()] });
+    const { tickets } = await getCheckoutConfig(prisma, { eventId: 'evt-1' });
+
+    expect(tickets).toHaveLength(1);
+    expect(tickets[0]).toMatchObject({
+      id: 'tt-1',
+      priceCents: 5000,
+      // 5000*0.08 + 50 = 450 base; +15% tax → round(517.5) = 518. Literal, not
+      // calculateFeesCents(5000), so a wrong fee formula can't pass on both sides.
+      feesCents: 518,
+      maxAllowedToAdd: 10, // min(availability 100, maxPurchasePerUser 10)
+      feeStructure: 'PASS_TICKET_FEES',
+      ticketType: 'PAID',
+      ticketQuantityLow: false,
+    });
+    expect(tickets[0].saleStartsAt).toBe(PAST.toISOString());
+    expect(tickets[0].isPasswordProtected).toBeUndefined();
+  });
+
+  it('nets active holds out of availability via reserved + sold', async () => {
+    // capacity 12 − reserved 3 − sold 4 = 5 available → low (<10), clamped.
+    const ticket = await firstTicket(
+      row({ capacity: 12, reserved: 3, sold: 4 })
+    );
+    expect(ticket.maxAllowedToAdd).toBe(5);
+    expect(ticket.ticketQuantityLow).toBe(true);
+  });
+
+  it('charges no fee when the organizer absorbs fees', async () => {
+    const ticket = await firstTicket(
+      row({ ticketingFees: 'ABSORB_TICKET_FEES' })
+    );
+    expect(ticket.feesCents).toBe(0);
+  });
+
+  it('blocks adds for draft events and closed sale windows', async () => {
+    expect(
+      (await firstTicket(row({ event: { isDraft: true } }))).maxAllowedToAdd
+    ).toBe(0);
+    expect(
+      (await firstTicket(row({ saleStartsAt: FUTURE, saleEndsAt: FUTURE })))
+        .maxAllowedToAdd
+    ).toBe(0);
+    expect(
+      (await firstTicket(row({ saleStartsAt: PAST, saleEndsAt: PAST })))
+        .maxAllowedToAdd
+    ).toBe(0);
+  });
+
+  it('sorts available tickets before sold-out, then by ascending price', async () => {
+    const prisma = fakePrisma({
+      ticketTypes: [
+        row({ id: 'cheap-soldout', priceCents: 1000, capacity: 0 }),
+        row({ id: 'pricey', priceCents: 9000 }),
+        row({ id: 'cheap', priceCents: 2000 }),
+      ],
+    });
+    const { tickets } = await getCheckoutConfig(prisma, { eventId: 'evt-1' });
+    expect(tickets.map((t) => t.id)).toEqual([
+      'cheap',
+      'pricey',
+      'cheap-soldout',
+    ]);
+  });
+
+  it('falls back to legacy columns before backfill', async () => {
+    const ticket = await firstTicket(
+      row({
+        priceCents: null,
+        price: 42,
+        capacity: null,
+        quantity: 7, // → availability 7, low
+        saleStartsAt: null,
+        saleEndsAt: null,
+      })
+    );
+    expect(ticket.priceCents).toBe(4200);
+    expect(ticket.ticketQuantityLow).toBe(true);
+    expect(ticket.maxAllowedToAdd).toBe(7);
+  });
+
+  it('returns an empty list for an event with no public tickets', async () => {
+    const prisma = fakePrisma({ ticketTypes: [], eventCount: 1 });
+    expect(await getCheckoutConfig(prisma, { eventId: 'evt-1' })).toEqual({
+      tickets: [],
+    });
+  });
+
+  it('throws NotFoundError when the event does not exist', async () => {
+    const prisma = fakePrisma({ ticketTypes: [], eventCount: 0 });
+    await expect(
+      getCheckoutConfig(prisma, { eventId: 'missing' })
+    ).rejects.toThrow('Event with ID missing not found.');
+  });
+});
+
+describe('applyCode', () => {
+  it('unlocks a matched code-gated ticket', async () => {
+    const prisma = fakePrisma({
+      matchedTicketType: row({ id: 'vip', name: 'VIP', priceCents: 15000 }),
+    });
+    const res = await applyCode(prisma, { eventId: 'evt-1', code: 'SECRET' });
+
+    expect(res.type).toBe('password');
+    expect(res.isValid).toBe(true);
+    if (res.type === 'password') {
+      expect(res.unlockedTicket.id).toBe('vip');
+      expect(res.unlockedTicket.priceCents).toBe(15000);
+      expect(res.unlockedTicket.isPasswordProtected).toBe(true);
+    }
+  });
+
+  it('returns an invalid result when no ticket matches the code', async () => {
+    const prisma = fakePrisma({ matchedTicketType: null });
+    const res = await applyCode(prisma, { eventId: 'evt-1', code: 'NOPE' });
+    expect(res).toEqual({
+      type: 'invalid',
+      isValid: false,
+      message: 'Invalid code.',
+    });
+  });
+});

--- a/packages/api/src/services/checkout.ts
+++ b/packages/api/src/services/checkout.ts
@@ -1,0 +1,179 @@
+/**
+ * Read-side checkout services: the public ticket list (`getCheckoutConfig`) and
+ * discount/password-code unlock (`applyCode`). Ports of
+ * `apps/web/src/app/api/checkout/{config,apply-code}/route.ts`, rewritten
+ * against the reservation-rebuild columns and the cents contract.
+ *
+ * Prisma is injected as the first argument (framework-agnostic, unit-testable
+ * with a fake). These are reads keyed off `eventId` / `code`, so — like the
+ * reservation primitives — they carry no authorization (ADR 0013).
+ *
+ * Availability = `capacity - reserved - sold` (the new counters), so active
+ * holds are already netted out via `reserved`; no separate pending-order query.
+ * The new columns (`capacity`/`priceCents`/`saleStartsAt`/`saleEndsAt`) are
+ * nullable until the Stage 3 backfill, so each read falls back to its legacy
+ * source during the transition — the fallback becomes dead code (removed with
+ * the M4–M12 legacy-column drops) once backfill lands.
+ */
+import type { PrismaClient, Prisma } from '@troptix/db';
+import {
+  type ApplyCodeInput,
+  type ApplyCodeResponse,
+  type CheckoutConfigInput,
+  type CheckoutConfigResponse,
+  type CheckoutTicket,
+} from '../contracts/checkout';
+import { calculateFeesCents } from './_shared/fees';
+import { NotFoundError } from './_shared/errors';
+
+// Exactly the columns the mapper needs — shared by both queries so they read
+// the same data. New reservation-rebuild columns first, legacy fallbacks next.
+const TICKET_TYPE_SELECT = {
+  id: true,
+  name: true,
+  description: true,
+  maxPurchasePerUser: true,
+  ticketingFees: true,
+  ticketType: true,
+  // New counters / cents / single-DateTime window (← backfilled).
+  capacity: true,
+  reserved: true,
+  sold: true,
+  priceCents: true,
+  saleStartsAt: true,
+  saleEndsAt: true,
+  // Legacy fallbacks (read until backfill; dropped in M4–M12).
+  quantity: true,
+  price: true,
+  saleStartDate: true,
+  saleEndDate: true,
+  event: { select: { isDraft: true } },
+} as const;
+
+type TicketTypeRow = Prisma.TicketTypesGetPayload<{
+  select: typeof TICKET_TYPE_SELECT;
+}>;
+
+/**
+ * Map a ticket-type row to its public `CheckoutTicket` shape — the availability,
+ * sale-window, and fee logic shared by `getCheckoutConfig` and `applyCode`.
+ * `now` is injected so callers compute against one consistent instant.
+ */
+function toCheckoutTicket(
+  tt: TicketTypeRow,
+  now: Date,
+  opts: { isPasswordProtected?: boolean } = {}
+): CheckoutTicket {
+  const priceCents = tt.priceCents ?? Math.round(tt.price * 100);
+  const capacity = tt.capacity ?? tt.quantity;
+  const saleStartsAt = tt.saleStartsAt ?? tt.saleStartDate;
+  const saleEndsAt = tt.saleEndsAt ?? tt.saleEndDate;
+
+  const availability = Math.max(0, capacity - tt.reserved - tt.sold);
+  const saleIsActive = now >= saleStartsAt && now <= saleEndsAt;
+  const maxAllowedToAdd =
+    saleIsActive && !tt.event.isDraft
+      ? Math.max(0, Math.min(availability, tt.maxPurchasePerUser))
+      : 0;
+  const feesCents =
+    tt.ticketingFees === 'PASS_TICKET_FEES'
+      ? calculateFeesCents(priceCents)
+      : 0;
+
+  return {
+    id: tt.id,
+    name: tt.name,
+    description: tt.description,
+    priceCents,
+    saleStartsAt: saleStartsAt.toISOString(),
+    saleEndsAt: saleEndsAt.toISOString(),
+    maxAllowedToAdd,
+    feesCents,
+    feeStructure: tt.ticketingFees,
+    ticketType: tt.ticketType,
+    ticketQuantityLow: availability > 0 && availability < 10,
+    ...(opts.isPasswordProtected ? { isPasswordProtected: true } : {}),
+  };
+}
+
+/**
+ * The public ticket list for an event's checkout: every non-code-gated ticket
+ * type, available ones first then by ascending price. Throws `NotFoundError`
+ * when the event itself doesn't exist (vs. an event with no public tickets,
+ * which returns an empty list).
+ */
+export async function getCheckoutConfig(
+  prisma: PrismaClient,
+  input: CheckoutConfigInput
+): Promise<CheckoutConfigResponse> {
+  const ticketTypes = await prisma.ticketTypes.findMany({
+    where: {
+      eventId: input.eventId,
+      // A null/empty discount code means the ticket is public.
+      OR: [
+        { discountCode: { equals: null } },
+        { discountCode: { equals: '' } },
+      ],
+    },
+    select: TICKET_TYPE_SELECT,
+    // No DB orderBy — the in-memory sort below (available-first, then by
+    // priceCents) is the source of truth and would re-order any DB sort anyway.
+  });
+
+  if (ticketTypes.length === 0) {
+    const eventExists = await prisma.events.count({
+      where: { id: input.eventId },
+    });
+    if (eventExists === 0) {
+      throw new NotFoundError(`Event with ID ${input.eventId} not found.`);
+    }
+    return { tickets: [] };
+  }
+
+  const now = new Date();
+  const tickets = ticketTypes
+    .map((tt) => toCheckoutTicket(tt, now))
+    .sort((a, b) => {
+      // Available (maxAllowedToAdd > 0) first, then by price ascending.
+      const aAvailable = a.maxAllowedToAdd > 0 ? 0 : 1;
+      const bAvailable = b.maxAllowedToAdd > 0 ? 0 : 1;
+      if (aAvailable !== bAvailable) return aAvailable - bAvailable;
+      return a.priceCents - b.priceCents;
+    });
+
+  return { tickets };
+}
+
+/**
+ * Unlock a code-gated ticket type. Returns a discriminated result — `password`
+ * with the unlocked ticket on a (case-insensitive) match, `invalid` otherwise.
+ * Not found is a normal `invalid` result, not a thrown error (the caller maps
+ * it to a 401/normal response).
+ */
+export async function applyCode(
+  prisma: PrismaClient,
+  input: ApplyCodeInput
+): Promise<ApplyCodeResponse> {
+  const match = await prisma.ticketTypes.findFirst({
+    where: {
+      eventId: input.eventId,
+      discountCode: { equals: input.code, mode: 'insensitive' },
+    },
+    select: TICKET_TYPE_SELECT,
+  });
+
+  if (!match) {
+    return { type: 'invalid', isValid: false, message: 'Invalid code.' };
+  }
+
+  const unlockedTicket = toCheckoutTicket(match, new Date(), {
+    isPasswordProtected: true,
+  });
+
+  return {
+    type: 'password',
+    isValid: true,
+    message: `Code applied successfully. "${unlockedTicket.name}" is now available.`,
+    unlockedTicket,
+  };
+}


### PR DESCRIPTION
Second slice of the API service layer ([plan](docs/plans/2026-06-api-service-layer.md)). Adds the **zod contracts** (the contract-freeze point) and the **read-side checkout services**, on the reservation-rebuild columns + the integer-cents contract. **Not yet wired into the live app.**

## What
- **`contracts/checkout.ts`** — one zod definition of the checkout wire shape (`CheckoutTicket`, `CheckoutConfig`, `ApplyCode`, `Validation` + message enums). **RN-safe** (zod + type-only `@troptix/db/types`). Prisma enums are mirrored as zod enums with **compile-time `AssertEqual` parity guards** — can't import the runtime enum *values* without breaking RN-safety, so the guard fails to compile if they ever drift. Money is **integer cents**. Re-exported from the package's type-only entry.
- **`services/checkout.ts`** — `getCheckoutConfig` + `applyCode`, `prisma` injected as the first arg. Availability = `capacity − reserved − sold`; reads fall back to legacy columns until the Stage-3 backfill (becomes dead code at M4–M12). Actor-agnostic ([ADR 0013](docs/adr/0013-authorization-in-the-service-layer.md)).
- **`services/_shared/fees.ts`** — cents-native port of `apps/web/src/lib/fees.ts` (same 8% + \$0.50 + 15%-tax rate card). Legacy dollar version retained for the un-wired legacy routes until Stage 3.
- **`services/_shared/errors.ts`** — transport-agnostic `NotFoundError` (adapters map to HTTP / `TRPCError`) + a documented throw-vs-return convention.

## Validation
- ✅ `tsc --noEmit` green (incl. the enum parity guards)
- ✅ **14 unit tests pass** (`fees` + `checkout`) with an injected fake `prisma` — **no Postgres** (ADR 0010)

## Notes
- `/simplify` reviewed: clean. One thing worth a `/code-review` eyeball before merge — `calculateFeesCents` rounds the total once while `getFeeBreakdownCents` rounds base+tax separately (both intentional + tested, matching the legacy single-round charge), so the *displayed* breakdown total could differ from the *charged* total by 1¢ for some prices. Deliberate, but flagging.
- Server callers wire to these in **PR 2c** (tRPC + webhook/cron); web's client migration is Stage 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)