### PR TITLE
Add PolyForm Noncommercial license (source-available, no business use)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
+# Verbatim license text — keep canonical, do not reformat
+LICENSE.md
+
 # Build artifacts
 **/dist
 **/build

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,153 @@
+TropTix is source-available software licensed under the **PolyForm
+Noncommercial License 1.0.0** (full text below).
+
+You may use, copy, modify, and share this software for any **noncommercial**
+purpose — personal projects, study, research, teaching, and use by nonprofit
+or government organizations are all permitted.
+
+**Commercial or business use is NOT permitted under this license.** This
+includes any use by or for a for-profit company, or any use with an
+anticipated commercial application.
+
+> Note: "Noncommercial" is a restriction on the field of use, so this license
+> is **source-available**, not OSI "open source." See the Definitions and
+> "Noncommercial Purposes" sections below for the precise terms.
+
+Need TropTix for commercial or business use? A separate **commercial license**
+is available. Contact Emmanuel Sylvester <emmanuel.sylvester22@gmail.com>.
+
+Required Notice: Copyright © 2026 Emmanuel Sylvester (TropTix)
+
+---
+
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose. However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software. Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software. For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else. These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice. Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+**_As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim._**
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization. **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise. Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/docs/adr/0015-polyform-noncommercial-license.md
+++ b/docs/adr/0015-polyform-noncommercial-license.md
@@ -1,0 +1,60 @@
+# 15. PolyForm Noncommercial License (source-available, no business use)
+
+- **Status:** Accepted
+- **Date:** 2026-06-10
+
+## Context
+
+The repository had no `LICENSE` file and the root `package.json` declared
+`"license": "ISC"` — a permissive OSI open-source license that grants anyone,
+including competitors, unrestricted commercial use. That does not match the
+intent for TropTix: the source should be public and readable, but **business /
+commercial use should require a separate paid license** from the maintainer.
+
+A few models can express "no business use":
+
+- **PolyForm Noncommercial 1.0.0** — purpose-built source-available license;
+  permits any noncommercial purpose (personal, hobby, study, research,
+  nonprofit, government), forbids commercial use. Cleanly drafted, SPDX-listed
+  (`PolyForm-Noncommercial-1.0.0`).
+- **Business Source License 1.1** — time-delayed open source; each version
+  auto-converts to a true OSS license after N years. Adds ongoing maintenance
+  (per-version change dates) and still eventually grants commercial rights.
+- **Functional Source License** — permits internal business use, only forbids
+  building a competing product; more permissive than we want.
+- **Fully proprietary** — grants no use/modify/share rights at all; more
+  restrictive than the goal of letting noncommercial users build on TropTix.
+
+Important framing: a license that discriminates against commercial use is **not
+OSI "open source"** (the Open Source Definition forbids restricting fields of
+endeavor). The correct term is **source-available**.
+
+## Decision
+
+License TropTix under **PolyForm Noncommercial License 1.0.0**, dual-licensed:
+
+- `LICENSE.md` contains the verbatim PolyForm text, a plain-language summary, a
+  `Required Notice:` copyright line, and a pointer to obtain a commercial
+  license.
+- Root `package.json` `license` field set to the SPDX id
+  `PolyForm-Noncommercial-1.0.0` (replacing `ISC`); `author` set to the
+  maintainer.
+- The maintainer **reserves the right to sell separate commercial licenses**
+  (open-core / dual-licensing). Commercial use is available by contacting
+  emmanuel.sylvester22@gmail.com.
+
+## Consequences
+
+- **Good** — source is public and contributable for noncommercial use; for-profit
+  use requires a paid license, preserving a commercialization path; the chosen
+  license is standard, SPDX-recognized, and well understood.
+- **Trade-off** — TropTix is **not** "open source" and must not be marketed as
+  such (it is source-available); it is ineligible for OSI/"open source"
+  ecosystems, some package registries, and certain corporate OSS programs.
+- **Trade-off** — noncommercial-only deters some contributors who will not
+  assign work to a commercially-licensable project; inbound contributions should
+  be covered by a CLA/DCO if commercial relicensing is to stay clean (future
+  work, not decided here).
+- **Care needed** — the PolyForm text must stay verbatim; only the surrounding
+  notice/preamble is ours to edit. The `Required Notice:` line propagates to all
+  redistributions per the Notices section.

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "packages/*"
   ],
   "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "author": "Emmanuel Sylvester",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.19.3",
     "typescript": "^5.2.2"


### PR DESCRIPTION
## What

Adds a license to TropTix that makes the source **public and usable for noncommercial purposes** but **prohibits commercial / business use** without a separate paid license.

- **`LICENSE.md`** (new) — verbatim **PolyForm Noncommercial License 1.0.0** (pulled from SPDX's canonical text), preceded by a plain-language summary, a `Required Notice:` copyright line, and a contact for commercial licensing.
- **`package.json`** — `license` changed `ISC` → `PolyForm-Noncommercial-1.0.0` (valid SPDX id); `author` set.
- **`docs/adr/0015-polyform-noncommercial-license.md`** (new) — ADR recording the decision and the rejected alternatives (BSL, FSL, fully proprietary).
- **`.prettierignore`** — excludes `LICENSE.md` so Prettier won't reflow the canonical legal text.

## Why

The repo had no `LICENSE` and declared `ISC` (a permissive OSI license granting anyone, including competitors, unrestricted commercial use). The intent for TropTix is source-available with commercial use reserved. PolyForm Noncommercial is purpose-built for exactly this, is SPDX-listed, and is well understood.

## Reviewer notes

- ⚠️ **This is *source-available*, not OSI "open source."** A no-commercial-use term discriminates against a field of endeavor, which the Open Source Definition forbids. Don't market TropTix as "open source." This framing is captured in the ADR.
- **Dual-licensed:** the maintainer reserves the right to sell commercial licenses (open-core model). Contact info is in `LICENSE.md`.
- **Permitted:** personal, hobby, study, research, teaching; nonprofit / educational / government use. **Not permitted:** any use by or for a for-profit company.
- The PolyForm text is **verbatim** — only the surrounding preamble is ours to edit.
- **Follow-ups (not in this PR):** only the root `package.json` carries a license field — `apps/*` / `packages/*` don't, so add the SPDX id there if any are published. Inbound contributions should be covered by a **CLA/DCO** to keep commercial relicensing clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)