### PR TITLE
Configure Matt Pocock engineering skills for this repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,3 +69,17 @@ created: YYYY-MM-DD
 tracking-issue: <#N or TBD>
 ---
 ```
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs live in `TropTix/troptix`'s GitHub Issues, managed via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical triage roles use their default label strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) — all present in GitHub. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one root `CONTEXT.md` (created lazily) + root `docs/adr/`. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,38 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This is a **single-context** repo: one `CONTEXT.md` + `docs/adr/` at the repo root.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root (created lazily — may not exist yet).
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. This repo keeps all ADRs at the root `docs/adr/`.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md            ← created lazily by /grill-with-docs
+├── docs/adr/
+│   ├── 0001-tailwind-v4-first.md
+│   ├── ...
+│   └── 0014-uuidv7-pks-and-public-codes.md
+└── ...
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (reservation-based checkout) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in `TropTix/troptix`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,17 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+All five labels exist in `TropTix/troptix`'s GitHub Issues.
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## What changed

Scaffolds the per-repo config the Matt Pocock engineering skills expect, created via `/setup-matt-pocock-skills`.

- **`docs/agents/issue-tracker.md`** — issues tracked in `TropTix/troptix`'s GitHub Issues via the `gh` CLI.
- **`docs/agents/triage-labels.md`** — maps the five canonical triage roles to label strings (defaults: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`).
- **`docs/agents/domain.md`** — declares this a single-context repo (one root `CONTEXT.md`, created lazily + root `docs/adr/`).
- **`CLAUDE.md`** — new `## Agent skills` section pointing at the three docs above.

## Why

Skills like `to-issues`, `triage`, `to-prd`, `qa`, `improve-codebase-architecture`, `diagnose`, `tdd`, and `grill-with-docs` read these files to know where issues live, which triage labels to apply, and how the domain docs are laid out.

## Reviewer notes

- Also created the four missing triage labels in GitHub (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`); `wontfix` already existed. No code is affected.
- No `CONTEXT.md` yet — that's expected; `/grill-with-docs` creates it lazily as domain terms get resolved.
- `CLAUDE.md` was chosen over `AGENTS.md` (both exist) per the skill's rule to edit the file that's already present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)