### PR TITLE
fix(api): make fee breakdown total match the charged fee

### DIFF
--- a/packages/api/src/services/_shared/fees.test.ts
+++ b/packages/api/src/services/_shared/fees.test.ts
@@ -31,12 +31,24 @@ describe('getFeeBreakdownCents', () => {
     });
   });
 
-  it('rounds the base first, then taxes the rounded base', () => {
-    // base round(450) = 450; tax round(450*0.15 = 67.5) = 68; total 518.
+  it('splits base + tax to sum to the charged total', () => {
+    // base round(450) = 450; total = charged 518; tax = 518 - 450 = 68.
     expect(getFeeBreakdownCents(5000)).toEqual({
       baseFeeCents: 450,
       taxCents: 68,
       totalCents: 518,
     });
+  });
+
+  it('total always equals the charged fee — no display/charge drift', () => {
+    // 8¢ is a case where independent rounding of base+tax would have diverged
+    // (round(50.64)=51 + round(7.65)=8 = 59) from the charged 58.
+    for (const priceCents of [
+      1, 8, 78, 85, 155, 169, 1000, 5000, 10000, 12345,
+    ]) {
+      const b = getFeeBreakdownCents(priceCents);
+      expect(b.totalCents).toBe(calculateFeesCents(priceCents));
+      expect(b.baseFeeCents + b.taxCents).toBe(b.totalCents);
+    }
   });
 });

--- a/packages/api/src/services/_shared/fees.ts
+++ b/packages/api/src/services/_shared/fees.ts
@@ -35,13 +35,21 @@ export function calculateFeesCents(priceCents: number): number {
   return Math.round(baseFee + baseFee * FeeConfig.TAX_RATE);
 }
 
-/** Detailed fee breakdown (base / tax / total) in integer cents, for display. */
+/**
+ * Detailed fee breakdown (base / tax / total) in integer cents, for display.
+ *
+ * The `totalCents` is the **authoritative charged fee** (`calculateFeesCents`),
+ * and `taxCents` is the remainder after the rounded base — so `base + tax`
+ * always equals the amount actually charged. (Rounding base and tax
+ * independently could make the displayed total differ from the charge by 1¢.)
+ */
 export function getFeeBreakdownCents(priceCents: number): FeeBreakdownCents {
-  if (priceCents <= 0) {
+  const totalCents = calculateFeesCents(priceCents);
+  if (totalCents === 0) {
     return { baseFeeCents: 0, taxCents: 0, totalCents: 0 };
   }
 
   const baseFeeCents = Math.round(rawBaseFeeCents(priceCents));
-  const taxCents = Math.round(baseFeeCents * FeeConfig.TAX_RATE);
-  return { baseFeeCents, taxCents, totalCents: baseFeeCents + taxCents };
+  const taxCents = totalCents - baseFeeCents;
+  return { baseFeeCents, taxCents, totalCents };
 }


### PR DESCRIPTION
`/code-review` follow-up to PR 2b (#298). The finding landed on `main` unfixed.

## The bug (latent)
`calculateFeesCents` rounds the total **once**; `getFeeBreakdownCents` rounded **base and tax independently** → the breakdown's `totalCents` could differ from the charged fee by **1¢** for some prices:
- `priceCents = 8` → charged **58**, breakdown total **59** (`round(50.64)=51` + `round(7.65)=8`).

Latent today (`getFeeBreakdownCents` has no live consumer — checkout charges via `calculateFeesCents`), but both are exported from `@troptix/api/server`, so a fee-breakdown display would mismatch the charge.

## Fix
`getFeeBreakdownCents` now derives `totalCents` from `calculateFeesCents` (authoritative charge) and sets `taxCents = total − round(base)`, so **base + tax always equals the charged total**. The charge is unchanged; only the breakdown's tax/total are made consistent.

## Validation
- ✅ 15 unit tests pass — incl. a new invariant `getFeeBreakdownCents(p).totalCents === calculateFeesCents(p)` over the previously-divergent prices (1, 8, 78, 85, 155, 169, …)
- ✅ typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)