### PR TITLE
Remove the tax-on-fee from the @troptix/api fee calculator

### DIFF
--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -22,10 +22,5 @@ export {
 } from './services/reservations';
 
 export { getCheckoutConfig, applyCode } from './services/checkout';
-export {
-  calculateFeesCents,
-  getFeeBreakdownCents,
-  FeeConfig,
-  type FeeBreakdownCents,
-} from './services/_shared/fees';
+export { calculateFeesCents, FeeConfig } from './services/_shared/fees';
 export { NotFoundError } from './services/_shared/errors';

--- a/packages/api/src/services/_shared/fees.test.ts
+++ b/packages/api/src/services/_shared/fees.test.ts
@@ -1,10 +1,10 @@
 /**
  * Unit tests for the fee rate card. Literal expected values (not re-derived
- * from FeeConfig), so a change to the percentage/fixed/tax — or to the rounding
- * — has to fail here rather than silently agreeing with itself.
+ * from FeeConfig), so a change to the percentage/fixed — or to the rounding —
+ * has to fail here rather than silently agreeing with itself.
  */
 import { describe, expect, it } from 'vitest';
-import { calculateFeesCents, getFeeBreakdownCents } from './fees';
+import { calculateFeesCents } from './fees';
 
 describe('calculateFeesCents', () => {
   it('charges nothing for free or non-positive prices', () => {
@@ -12,31 +12,9 @@ describe('calculateFeesCents', () => {
     expect(calculateFeesCents(-100)).toBe(0);
   });
 
-  it('applies 8% + $0.50, then 15% tax, rounded to whole cents', () => {
-    // 5000*0.08 + 50 = 450 base; 450 + 450*0.15 = 517.5 → round → 518.
-    expect(calculateFeesCents(5000)).toBe(518);
-    // 10000*0.08 + 50 = 850 base; 850 + 127.5 = 977.5 → round → 978.
-    expect(calculateFeesCents(10000)).toBe(978);
-    // 1*0.08 + 50 = 50.08 base; 50.08 + 7.512 = 57.592 → round → 58.
-    expect(calculateFeesCents(1)).toBe(58);
-  });
-});
-
-describe('getFeeBreakdownCents', () => {
-  it('is all zeros for free tickets', () => {
-    expect(getFeeBreakdownCents(0)).toEqual({
-      baseFeeCents: 0,
-      taxCents: 0,
-      totalCents: 0,
-    });
-  });
-
-  it('rounds the base first, then taxes the rounded base', () => {
-    // base round(450) = 450; tax round(450*0.15 = 67.5) = 68; total 518.
-    expect(getFeeBreakdownCents(5000)).toEqual({
-      baseFeeCents: 450,
-      taxCents: 68,
-      totalCents: 518,
-    });
+  it('applies 8% + $0.50, rounded to whole cents (no tax)', () => {
+    expect(calculateFeesCents(5000)).toBe(450); // 5000*0.08 + 50 = 450
+    expect(calculateFeesCents(10000)).toBe(850); // 800 + 50
+    expect(calculateFeesCents(1)).toBe(50); // round(50.08) = 50
   });
 });

--- a/packages/api/src/services/_shared/fees.ts
+++ b/packages/api/src/services/_shared/fees.ts
@@ -1,47 +1,24 @@
 /**
- * Platform fee calculation — cents-native port of `apps/web/src/lib/fees.ts`.
+ * Platform fee calculation — cents-native, for the service layer (roadmap 2.12).
  *
- * The service layer works in integer cents end-to-end (roadmap 2.12), so these
- * take and return cents rather than the legacy dollar `Float`s. Same rate card
- * (8% + $0.50, then 15% tax on the fee) as the legacy helper, so a given price
- * yields the same fee — just expressed in cents. The legacy dollar version is
- * retained in `apps/web` for the un-wired legacy routes until Stage 3.
+ * The fee is a flat **8% + $0.50** of the ticket price (no tax-on-fee). Free /
+ * non-positive prices carry no fee.
+ *
+ * NB: this intentionally diverges from the legacy `apps/web/src/lib/fees.ts`,
+ * which still applies the old 15% tax-on-fee. The legacy helper is left
+ * unchanged for the un-wired legacy routes until the Stage 3 cutover; the fee
+ * actually charged drops (no tax) when the app moves onto this service.
  */
 export const FeeConfig = {
   PERCENTAGE: 0.08, // 8% base fee
   FIXED_CENTS: 50, // $0.50 fixed fee
-  TAX_RATE: 0.15, // 15% tax on fees
 } as const;
 
-export interface FeeBreakdownCents {
-  baseFeeCents: number;
-  taxCents: number;
-  totalCents: number;
-}
-
 /**
- * Total fee (base + tax) for a ticket price, in integer cents.
- * Free tickets carry no fee.
+ * Platform fee for a ticket price, in integer cents: `round(8% + $0.50)`.
+ * Free / non-positive prices carry no fee.
  */
-/** The unrounded base fee (percentage + fixed) in cents — the rate-card formula. */
-function rawBaseFeeCents(priceCents: number): number {
-  return priceCents * FeeConfig.PERCENTAGE + FeeConfig.FIXED_CENTS;
-}
-
 export function calculateFeesCents(priceCents: number): number {
   if (priceCents <= 0) return 0;
-
-  const baseFee = rawBaseFeeCents(priceCents);
-  return Math.round(baseFee + baseFee * FeeConfig.TAX_RATE);
-}
-
-/** Detailed fee breakdown (base / tax / total) in integer cents, for display. */
-export function getFeeBreakdownCents(priceCents: number): FeeBreakdownCents {
-  if (priceCents <= 0) {
-    return { baseFeeCents: 0, taxCents: 0, totalCents: 0 };
-  }
-
-  const baseFeeCents = Math.round(rawBaseFeeCents(priceCents));
-  const taxCents = Math.round(baseFeeCents * FeeConfig.TAX_RATE);
-  return { baseFeeCents, taxCents, totalCents: baseFeeCents + taxCents };
+  return Math.round(priceCents * FeeConfig.PERCENTAGE + FeeConfig.FIXED_CENTS);
 }

--- a/packages/api/src/services/checkout.test.ts
+++ b/packages/api/src/services/checkout.test.ts
@@ -90,9 +90,9 @@ describe('getCheckoutConfig', () => {
     expect(tickets[0]).toMatchObject({
       id: 'tt-1',
       priceCents: 5000,
-      // 5000*0.08 + 50 = 450 base; +15% tax → round(517.5) = 518. Literal, not
-      // calculateFeesCents(5000), so a wrong fee formula can't pass on both sides.
-      feesCents: 518,
+      // 5000*0.08 + 50 = 450 fee (no tax). Literal, not calculateFeesCents(5000),
+      // so a wrong fee formula can't pass on both sides.
+      feesCents: 450,
       maxAllowedToAdd: 10, // min(availability 100, maxPurchasePerUser 10)
       feeStructure: 'PASS_TICKET_FEES',
       ticketType: 'PAID',


### PR DESCRIPTION
The platform fee becomes a flat **8% + \$0.50** of the ticket price — drop the 15% tax-on-fee.

## Scope: new service only (no live impact)
Changes `packages/api/src/services/_shared/fees.ts`, which is **not yet wired into the live app**. Customers are unaffected until the Stage 3 cutover. The legacy `apps/web/src/lib/fees.ts` (which still applies the tax) is **left untouched** for the live legacy routes — per your "new service only" call.

For a \$50 ticket the service fee is **450¢** (was 518¢ with tax).

## What changed
- `FeeConfig`: drop `TAX_RATE`. `calculateFeesCents = round(price*0.08 + 50)`.
- Remove `getFeeBreakdownCents` + `FeeBreakdownCents` — with no tax there's nothing to break down, and they had **no consumers**. Dropped from the `@troptix/api/server` re-exports too.
- Tests updated to the no-tax values; the breakdown tests removed. `checkout.test.ts`'s hardcoded fee 518 → 450.

## Supersedes #303
#303 made `getFeeBreakdownCents`'s rounding consistent — this PR deletes that function, so #303 is moot and has been closed.

## Validation
- ✅ typecheck green (`@troptix/api`)
- ✅ 12 unit tests pass (fees + checkout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)