### PR TITLE
fix(auth): forced google account picker during sign in

### DIFF
--- a/apps/web/src/lib/supabaseAuth.ts
+++ b/apps/web/src/lib/supabaseAuth.ts
@@ -28,6 +28,7 @@ export async function signInWithGoogle() {
   return supabase.auth.signInWithOAuth({
     provider: 'google',
     options: { redirectTo: `${window.location.origin}/auth/callback` },
+    queryParams: { prompt: 'select_account' },
   });
 }
 


### PR DESCRIPTION
Added `prompt: 'select_account'` to the Google OAuth sign-in options to ensure users are prompted to select an account, preventing automatic login with the previously authenticated session.