### PR TITLE
Generate the Prisma client during the Vercel build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "dev:mobile": "tsx scripts/dev-mobile.ts",
     "email": "email dev",
+    "prebuild": "yarn workspace @troptix/db generate",
     "build": "next build",
     "typecheck": "tsc --noEmit",
     "start": "next start",


### PR DESCRIPTION
## Problem

Vercel builds fail with:

```
./packages/db/src/index.ts:15:1
Module not found: Can't resolve './generated/prisma/client'
```

cascading into every missing `@troptix/db` export (`OrderStatus`, `Prisma`, `TicketStatus`, `ReservationStatus`, …) across the app.

## Cause

`@troptix/db`'s generated Prisma client (Prisma 7, output to `packages/db/src/generated/prisma`, **gitignored**) is produced **only** by `packages/db`'s `postinstall: prisma generate`. `apps/web`'s build is plain `next build`. On Vercel, a build-cache-restored `yarn install` reports *"Already up-to-date"* and **skips workspace `postinstall` scripts**, so the client is never generated and the build can't resolve it.

This is latent on `main` — it surfaces whenever an install is a full cache hit.

## Fix

Add a `prebuild` to `apps/web` that regenerates the client before `next build`:

```jsonc
"prebuild": "yarn workspace @troptix/db generate",
"build": "next build",
```

`npm`/`yarn` run `prebuild` automatically before `build`, so the client is produced on **every** deploy regardless of install caching. `prisma generate` reads only the schema (no DB connection), so it's safe and fast (~85ms locally).

Verified `yarn workspace @troptix/db generate` regenerates `packages/db/src/generated/prisma/client.ts` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)