### PR TITLE
Resolve flyer paths in confirmation email + standardize event-page fallback

### DIFF
--- a/apps/web/src/app/events/[eventId]/_components/EventDetails.tsx
+++ b/apps/web/src/app/events/[eventId]/_components/EventDetails.tsx
@@ -19,7 +19,7 @@ import { Banner } from '@/components/ui/banner';
 import { Button } from '@/components/ui/button';
 import { Calendar, DollarSign, MapPin, Ticket } from 'lucide-react';
 import Image from 'next/image';
-import { eventFlyerUrl } from '@/lib/supabase/storage';
+import { eventFlyerUrl, DEFAULT_EVENT_IMAGE } from '@/lib/supabase/storage';
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 import {
@@ -75,8 +75,7 @@ export default function EventDetail({ event }: { event: EventById }) {
     });
   }
   const resolvedImageUrl = eventFlyerUrl(event.imageUrl);
-  const displayImageUrl =
-    resolvedImageUrl ?? 'https://placehold.co/400x400?text=Add+Event+Flyer';
+  const displayImageUrl = resolvedImageUrl ?? DEFAULT_EVENT_IMAGE;
 
   const displayPrice =
     event.ticketTypes && event.ticketTypes.length > 0
@@ -126,10 +125,7 @@ export default function EventDetail({ event }: { event: EventById }) {
                     maxWidth: 350,
                     objectFit: 'fill',
                   }}
-                  src={
-                    resolvedImageUrl ??
-                    'https://placehold.co/600x600.png?text=Add+Event+Flyer'
-                  }
+                  src={resolvedImageUrl ?? DEFAULT_EVENT_IMAGE}
                   alt={event.name}
                   className="mb-8 max-h-full flex-shrink-0 self-center object-fill overflow-hidden rounded-lg mx-auto"
                 />

--- a/apps/web/src/server/lib/email.ts
+++ b/apps/web/src/server/lib/email.ts
@@ -3,6 +3,7 @@ import { Prisma } from '@troptix/db';
 import { createElement } from 'react';
 import { render } from '@react-email/components';
 import EmailConfirmationTemplate from '@emails/EmailConfirmation';
+import { eventFlyerUrl } from '@/lib/supabase/storage';
 import { Resend } from 'resend';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
@@ -55,10 +56,17 @@ export async function sendEmailConfirmationEmailToUser(orderId: string) {
 }
 
 async function createEmailConfirmationEmailHTML(orderDetails: OrderDetails) {
+  // imageUrl now stores a Supabase bucket PATH (ADR 0016), and email clients
+  // can't resolve a relative src — resolve it to an absolute URL before render.
+  const order = {
+    ...orderDetails,
+    event: {
+      ...orderDetails.event,
+      imageUrl: eventFlyerUrl(orderDetails.event.imageUrl),
+    },
+  };
   const html = await render(
-    createElement(EmailConfirmationTemplate, {
-      order: orderDetails,
-    })
+    createElement(EmailConfirmationTemplate, { order })
   );
   return html;
 }


### PR DESCRIPTION
Follow-up to [#330](https://github.com/TropTix/troptix/pull/330). Now that `Events.imageUrl` holds a Supabase bucket **path** ([ADR 0016](docs/adr/0016-supabase-storage-for-event-images.md)), two consumers that render it raw need fixing. The dev data migration surfaced these.

## Email — `email.ts`
The order-confirmation email rendered `src={event.imageUrl}` (a bare path), which email clients can't resolve → broken event image in every confirmation. Resolved at the data boundary in `createEmailConfirmationEmailHTML` via `eventFlyerUrl()`, so the template receives an absolute URL. Customer-facing.

## Event page — `EventDetails.tsx`
The event detail page fell back to remote `placehold.co` URLs for the no-flyer state, while the rest of the app uses the local `DEFAULT_EVENT_IMAGE`. Standardized on `DEFAULT_EVENT_IMAGE` — drops the third-party dependency and the inconsistent placeholder visual.

## Out of scope (by request)
The `/api/organizer/events` → **mobile organizer app** still returns/renders the raw path. Deliberately **not** in this PR.

Verified: `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)