### PR TITLE
Rebuild event image picker on a native <label> trigger

### DIFF
--- a/apps/web/src/app/events/[eventId]/_components/EventDetails.tsx
+++ b/apps/web/src/app/events/[eventId]/_components/EventDetails.tsx
@@ -125,7 +125,7 @@ export default function EventDetail({ event }: { event: EventById }) {
                     maxWidth: 350,
                     objectFit: 'fill',
                   }}
-                  src={resolvedImageUrl ?? DEFAULT_EVENT_IMAGE}
+                  src={displayImageUrl}
                   alt={event.name}
                   className="mb-8 max-h-full flex-shrink-0 self-center object-fill overflow-hidden rounded-lg mx-auto"
                 />

--- a/apps/web/src/app/organizer/events/_components/EventImageUpload.tsx
+++ b/apps/web/src/app/organizer/events/_components/EventImageUpload.tsx
@@ -1,14 +1,12 @@
-// components/EventImageUploader.tsx
 'use client';
 
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useId } from 'react';
 import {
   uploadEventFlyer,
   deleteEventFlyer,
   eventFlyerUrl,
 } from '@/lib/supabase/storage';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import {
   UploadCloud,
@@ -17,12 +15,9 @@ import {
   AlertCircle,
   Loader2,
 } from 'lucide-react';
-import Image from 'next/image'; // Use Next.js Image for optimization
+import Image from 'next/image';
 
 interface EventImageUploaderProps {
-  // `currentImageUrl` carries the stored value, which is now a Supabase Storage
-  // PATH (ADR 0016), not a URL. `onUploadComplete` likewise emits a path (or
-  // null when cleared). Previews are resolved to URLs via eventFlyerUrl().
   currentImageUrl?: string | null;
   onUploadComplete: (path: string | null) => void;
 }
@@ -31,8 +26,7 @@ export function EventImageUploader({
   currentImageUrl,
   onUploadComplete,
 }: EventImageUploaderProps) {
-  // The stored value resolved to a renderable URL — the fallback whenever there
-  // is no in-progress local selection. Derived from the prop, recomputed per render.
+  const inputId = useId();
   const resolvedCurrentUrl = eventFlyerUrl(currentImageUrl);
   const [file, setFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(
@@ -56,7 +50,6 @@ export function EventImageUploader({
       setPreviewUrl(objectUrl);
     }
 
-    // Cleanup function
     return () => {
       if (objectUrl) {
         URL.revokeObjectURL(objectUrl);
@@ -89,10 +82,6 @@ export function EventImageUploader({
     }
   };
 
-  const triggerFileInput = () => {
-    fileInputRef.current?.click();
-  };
-
   const handleUpload = async () => {
     if (!file) {
       setError('No file selected.');
@@ -103,7 +92,6 @@ export function EventImageUploader({
     setError(null);
 
     try {
-      // Returns the stored bucket path (what goes into Events.imageUrl).
       const path = await uploadEventFlyer(file);
       setPreviewUrl(eventFlyerUrl(path));
       onUploadComplete(path);
@@ -145,7 +133,6 @@ export function EventImageUploader({
       }
     }
 
-    // Reset the file input
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
@@ -153,12 +140,13 @@ export function EventImageUploader({
 
   return (
     <div className="space-y-4">
-      <Input
+      <input
+        id={inputId}
         type="file"
         ref={fileInputRef}
         onChange={handleFileSelect}
         accept="image/*"
-        className="hidden"
+        className="sr-only"
         disabled={isUploading}
       />
 
@@ -189,14 +177,14 @@ export function EventImageUploader({
             <ImageIcon className="mx-auto h-12 w-12 mb-2" />
             <p className="text-sm">No image selected</p>
             <Button
-              type="button"
+              asChild
               variant="outline"
               size="sm"
-              className="mt-2"
-              onClick={triggerFileInput}
-              disabled={isUploading}
+              className="mt-2 cursor-pointer"
             >
-              <UploadCloud className="mr-2 h-4 w-4" /> Select Image
+              <label htmlFor={inputId}>
+                <UploadCloud className="mr-2 h-4 w-4" /> Select Image
+              </label>
             </Button>
           </div>
         )}
@@ -210,13 +198,14 @@ export function EventImageUploader({
 
       {previewUrl && !isUploading && (
         <Button
-          type="button"
+          asChild
           variant="outline"
           size="sm"
-          onClick={triggerFileInput}
-          className="w-full"
+          className="w-full cursor-pointer"
         >
-          <UploadCloud className="mr-2 h-4 w-4" /> Change Image
+          <label htmlFor={inputId}>
+            <UploadCloud className="mr-2 h-4 w-4" /> Change Image
+          </label>
         </Button>
       )}
 


### PR DESCRIPTION
Recovers two commits that were stranded on `fix/event-email-image-consumers` after [#333](https://github.com/TropTix/troptix/pull/333) was **squash-merged** — the squash captured only the branch state at merge time, so these never reached `main`.

## What's here
- **Picker rebuild** — the "Select Image" / "Change Image" trigger now uses a native `<label htmlFor>` (via `Button asChild`) instead of a `display:none` input + JS `fileInputRef.current.click()`. The OS picker opens through the browser's built-in label behavior — no dependence on transient user-activation. Input is kept in-layout but visually hidden (`sr-only`). Drops the now-unused `triggerFileInput` and `Input` import.
- **`useId()`** for the input id (was a hardcoded `"event-flyer-input"`) so the `<label htmlFor>` association can't collide if the component mounts twice on a page.
- **`EventDetails`** — `<Image src>` reuses `displayImageUrl` instead of recomputing the now-identical `resolvedImageUrl ?? DEFAULT_EVENT_IMAGE`.

## Note
The picker symptom that prompted this turned out to be a **wedged Chrome file-dialog state** (fixed by restarting Chrome) — not the app. The native-`<label>` rebuild is a genuine robustness improvement regardless and was reviewed via `/simplify`.

Verified: `tsc` clean; changed files ESLint-clean (only the pre-existing `handleUpload` exhaustive-deps warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)